### PR TITLE
Add natural sorting to ioc instances output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 description = "One line description of your module"
-dependencies = ["typer[all]", "requests", "ruamel.yaml", "jinja2"]
+dependencies = ["natsort", "typer[all]", "requests", "ruamel.yaml", "jinja2"]
 
 # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]

--- a/src/epics_containers_cli/ioc/ioc_cli.py
+++ b/src/epics_containers_cli/ioc/ioc_cli.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 import typer
+from natsort import natsorted
 
 from epics_containers_cli.git import create_ioc_graph
 from epics_containers_cli.globals import LOCAL_NAMESPACE
@@ -134,7 +135,9 @@ def instances(
         iocs_list = ioc_graph[ioc_name]
     except KeyError:
         iocs_list = []
-    typer.echo("  ".join(iocs_list))
+
+    sorted_list = natsorted(iocs_list)[::-1]
+    typer.echo("  ".join(sorted_list))
 
 
 @ioc.command()


### PR DESCRIPTION
Currently when running `ec ioc instances bl01j-di-dcam-01`

We get:
```
Available instance versions for bl01j-di-dcam-01:
2023.11.10  2023.11.4  2023.11.5  2023.11.6  2023.11.7  2023.11.8  2023.11.9
```

To rather get:
```
Available instance versions for bl01j-di-dcam-01:
2023.11.10  2023.11.9  2023.11.8  2023.11.7  2023.11.6  2023.11.5  2023.11.4
```