### PR TITLE
Fix ioc template helm arguments

### DIFF
--- a/src/epics_containers_cli/ioc/helm.py
+++ b/src/epics_containers_cli/ioc/helm.py
@@ -124,13 +124,14 @@ class Helm:
         # complicated stderr filter to suppress helm symlink warnings
         cmd = (
             f"bash -c "
-            f'"helm {helm_cmd} {self.ioc_name} {self.bl_chart_folder} '
+            f'"'
+            f"helm {helm_cmd} {self.ioc_name} {self.bl_chart_folder} "
             f"--version {self.version} --namespace {self.namespace} -f {values} "
             f"--set ioc_name={self.ioc_name} --set ioc_version={self.version} "
-            f" 2> >(grep -v 'found symbolic link' >&2)\""
+            f" 2> >(grep -v 'found symbolic link' >&2) "
+            f"{self.args}"
+            f'"'
         )
-        if self.args:
-            cmd += f" {self.args}"
 
         output = run_command(cmd, interactive=False)
         typer.echo(output)

--- a/src/epics_containers_cli/ioc/helm.py
+++ b/src/epics_containers_cli/ioc/helm.py
@@ -128,8 +128,8 @@ class Helm:
             f"helm {helm_cmd} {self.ioc_name} {self.bl_chart_folder} "
             f"--version {self.version} --namespace {self.namespace} -f {values} "
             f"--set ioc_name={self.ioc_name} --set ioc_version={self.version} "
-            f" 2> >(grep -v 'found symbolic link' >&2) "
             f"{self.args}"
+            f" 2> >(grep -v 'found symbolic link' >&2) "
             f'"'
         )
 

--- a/src/epics_containers_cli/ioc/ioc_cli.py
+++ b/src/epics_containers_cli/ioc/ioc_cli.py
@@ -64,13 +64,12 @@ def template(
         resolve_path=True,
         autocompletion=force_plain_completion,
     ),
-    debug: bool = typer.Option(False, help="Enable verbose output for helm"),
     args: str = typer.Option("", help="Additional args for helm, 'must be quoted'"),
 ):
     """
     print out the helm template generated from a local ioc instance
     """
-    args = f"{args} --debug" if debug else args
+    args = f"{args} --debug"
     if ctx.obj.namespace == LOCAL_NAMESPACE:
         typer.echo("Not applicable to local deployments")
     else:

--- a/src/epics_containers_cli/ioc/ioc_cli.py
+++ b/src/epics_containers_cli/ioc/ioc_cli.py
@@ -64,11 +64,13 @@ def template(
         resolve_path=True,
         autocompletion=force_plain_completion,
     ),
+    debug: bool = typer.Option(False, help="Enable verbose output for helm"),
     args: str = typer.Option("", help="Additional args for helm, 'must be quoted'"),
 ):
     """
     print out the helm template generated from a local ioc instance
     """
+    args = f"{args} --debug" if debug else args
     if ctx.obj.namespace == LOCAL_NAMESPACE:
         typer.echo("Not applicable to local deployments")
     else:


### PR DESCRIPTION
Closes #75 - Now places helm args in the command. Debug is added as an explicit command line option