### PR TITLE
add new mandatory project_folder build arg to "dev build"

### DIFF
--- a/src/epics_containers_cli/dev/dev_cli.py
+++ b/src/epics_containers_cli/dev/dev_cli.py
@@ -201,7 +201,11 @@ def wait_pv(
 def build(
     ctx: typer.Context,
     generic_ioc: Path = typer.Option(
-        Path("."), help="Generic IOC project folder", exists=True, file_okay=False
+        Path("."),
+        help="Generic IOC project folder",
+        exists=True,
+        file_okay=False,
+        resolve_path=True,
     ),
     tag: str = typer.Option(IMAGE_TAG, help="version tag for the image"),
     arch: Architecture = typer.Option(

--- a/src/epics_containers_cli/dev/dev_commands.py
+++ b/src/epics_containers_cli/dev/dev_commands.py
@@ -204,6 +204,7 @@ class DevCommands:
         repo, _ = get_git_name(generic_ioc)
         args = f"--platform {platform} {'--no-cache' if not cache else ''}"
         tag = normalize_tag(tag)
+        args += f" --build-arg PROJECT_NAME={generic_ioc.name}"
 
         if target is None:
             targets = [Targets.developer.value, Targets.runtime.value]

--- a/tests/data/dev.yaml
+++ b/tests/data/dev.yaml
@@ -91,7 +91,7 @@ wait_pv:
     rsp: "BL45P-EA-IOC-01:UPTIME 00:00:07"
 
 build:
-  - cmd: podman build --target developer --build-arg TARGET_ARCHITECTURE=linux --platform linux/amd64  -t ghcr.io/epics-containers/bl45p-linux-developer:local .
+  - cmd: podman build --target developer --build-arg TARGET_ARCHITECTURE=linux --platform linux/amd64  --build-arg PROJECT_NAME=ioc-template -t ghcr.io/epics-containers/bl45p-linux-developer:local .
     rsp: True
-  - cmd: podman build --target runtime --build-arg TARGET_ARCHITECTURE=linux --platform linux/amd64  -t ghcr.io/epics-containers/bl45p-linux-runtime:local .
+  - cmd: podman build --target runtime --build-arg TARGET_ARCHITECTURE=linux --platform linux/amd64  --build-arg PROJECT_NAME=ioc-template -t ghcr.io/epics-containers/bl45p-linux-runtime:local .
     rsp: True

--- a/tests/data/ioc-template/readme.txt
+++ b/tests/data/ioc-template/readme.txt
@@ -1,0 +1,4 @@
+This folder used as a pretend generic ioc source folder folder
+testing
+
+ec dev build

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -65,4 +65,4 @@ def test_wait_pv(mock_run, dev, data):
 
 def test_build(mock_run, dev, data):
     mock_run.set_seq(dev.checks + dev.get_git_name + dev.build)
-    mock_run.run_cli("dev build")
+    mock_run.run_cli(f"dev build --generic-ioc {data / 'ioc-template'}")


### PR DESCRIPTION
Due to a change in ibek and the ioc-xxxx Dockerfiles we now require an extra build arg to the generic ioc build.