### PR TITLE
Fix error in detecting service tags

### DIFF
--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -137,15 +137,23 @@ def create_svc_graph(repo: str, folder: Path) -> dict:
             tags = result.split("\n")
             tags.remove("")
 
+            # Check initial configuration
+            tag = tags[0]
+            cmd = f"git ls-tree -r {tag} --name-only"
+            result = str(shell.run_command(cmd, interactive=False, error_OK=True))
+            if service_name in result:
+                version_list.append(tag)
+
+            # Check repo changes
             for tag in tags:
                 cmd = f"git diff --name-only {tag} {tag}^"
                 result = str(shell.run_command(cmd, interactive=False, error_OK=True))
                 if service_name in result:
                     version_list.append(tag)
 
+            # Capture services preceding a tag
             if not version_list:
-                # give the latest tag if there are no changes
-                version_list.append(tags[-1])
+                version_list.append("")
 
             svc_graph[service_name] = version_list
 

--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -151,7 +151,7 @@ def create_svc_graph(repo: str, folder: Path) -> dict:
                 if service_name in result:
                     version_list.append(tag)
 
-            # Capture services preceding a tag
+            # Capture services committed since the most recent tag
             if not version_list:
                 version_list.append("")
 

--- a/tests/data/autocomplete.yaml
+++ b/tests/data/autocomplete.yaml
@@ -18,6 +18,9 @@ avail_IOCs:
   - cmd: git tag
     rsp: |
       2.0
+  - cmd: git ls-tree -r 2.0 --name-only
+    rsp: |
+      2.0
   - cmd: git diff --name-only 2.0 2.0\^
     rsp: |
       2.0 bl45p-ea-ioc-01
@@ -26,6 +29,9 @@ avail_versions:
   - cmd: git clone https://github.com/epics-containers/bl45p /tmp/.*
     rsp: Cloning into /tmp/xxxx...
   - cmd: git tag
+    rsp: |
+      2.0
+  - cmd: git ls-tree -r 2.0 --name-only
     rsp: |
       2.0
   - cmd: git diff --name-only 2.0 2.0\^

--- a/tests/data/ioc.yaml
+++ b/tests/data/ioc.yaml
@@ -43,6 +43,9 @@ instances:
   - cmd: git tag
     rsp: |
       2.0
+  - cmd: git ls-tree -r 2.0 --name-only
+    rsp: |
+      2.0
   - cmd: git diff --name-only 2.0 2.0\^
     rsp: |
       2.0 bl45p-ea-ioc-01

--- a/tests/data/local.yaml
+++ b/tests/data/local.yaml
@@ -69,6 +69,9 @@ instances:
   - cmd: git tag
     rsp: |
       2.0
+  - cmd: git ls-tree -r 2.0 --name-only
+    rsp: |
+      2.0
   - cmd: git diff --name-only 2.0 2.0\^
     rsp: |
       2.0


### PR DESCRIPTION
Currently when running `ec list`
```
(.venv) [esq51579@pc0146 edge-containers-cli]$ ec list
Available services:                Latest instance:
bl01c-di-dcam-01                   2024.2.4    # This is correct
bl01c-di-dcam-02                   2024.2.5    # This is correct
bl01c-ea-test-01                   2024.2.6    # No change since first tag - Not correct
bl01c-ea-test-02                   2024.2.3    # This is correct
bl01c-ea-test-03                   2024.2.6    # Commited after tag 2024.2.6 - Not correct
bl01c-mo-ioc-01                    2024.2.6    # This is correct
epics-opis                         2024.2.6    # No change since first tag - Not correct
epics-pvcs                         2024.2.6    # No change since first tag - Not correct
```

This commit adds:
- to check what is tracked at the first tag as a starting point - and then using the diff between tags from there
- services remaining have been commited after any tag and should therefore not receive the latest tag

```
Available services:                Latest instance:
bl01c-di-dcam-01                   2024.2.4
bl01c-di-dcam-02                   2024.2.5
bl01c-ea-test-01                   2024.2.1
bl01c-ea-test-02                   2024.2.3
bl01c-ea-test-03                   
bl01c-mo-ioc-01                    2024.2.6
epics-opis                         2024.2.1
epics-pvcs                         2024.2.1
```
solves #100 