### PR TITLE
Local deploy versioning

### DIFF
--- a/src/edge_containers_cli/cmds/helm.py
+++ b/src/edge_containers_cli/cmds/helm.py
@@ -1,5 +1,4 @@
 import tempfile
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -7,7 +6,13 @@ import typer
 
 import edge_containers_cli.globals as globals
 import edge_containers_cli.shell as shell
-from edge_containers_cli.utils import chdir, check_instance_path, cleanup_temp, log
+from edge_containers_cli.utils import (
+    chdir,
+    check_instance_path,
+    cleanup_temp,
+    local_version,
+    log,
+)
 
 
 class Helm:
@@ -31,9 +36,7 @@ class Helm:
         self.beamline_repo = repo
         self.namespace = namespace
         self.args = args
-        self.version = version or datetime.strftime(
-            datetime.now(), "%Y.%-m.%-d-b%-H.%-M"
-        )
+        self.version = version or local_version()
         self.template = template
 
         self.tmp = Path(tempfile.mkdtemp())

--- a/src/edge_containers_cli/cmds/local_commands.py
+++ b/src/edge_containers_cli/cmds/local_commands.py
@@ -32,6 +32,7 @@ from edge_containers_cli.utils import (
     cleanup_temp,
     generic_ioc_from_image,
     get_instance_image_name,
+    local_version,
 )
 
 
@@ -121,7 +122,7 @@ class LocalCommands:
         Use a local copy of an ioc instance definition to deploy a temporary
         version of the IOC to the local docker instance
         """
-        version = datetime.strftime(datetime.now(), "%Y.%-m.%-d-b%-H.%-M")
+        version = local_version()
         if not yes:
             typer.echo(
                 f"Deploy TEMPORARY version {version} "

--- a/src/edge_containers_cli/utils.py
+++ b/src/edge_containers_cli/utils.py
@@ -6,6 +6,7 @@ import contextlib
 import os
 import re
 import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -111,3 +112,15 @@ def normalize_tag(tag: str) -> str:
     tag = tag.lower()
     tag = tag.replace("/", "-")
     return tag
+
+
+def local_version() -> str:
+    """
+    create a CalVer style YYYY:MM:MICRO-b version where MICRO
+    is derived from DD:HH:MM:SS in seconds in base 16
+    """
+    time_now = datetime.now()
+    time_month = time_now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    elapsed = (time_now - time_month).seconds
+    elapsed_base = hex(elapsed)[2:]
+    return datetime.strftime(time_now, f"%Y.%-m.{elapsed_base}-b")


### PR DESCRIPTION
For facilities that adopt a CalVer scheme of YYYY.MM.MINOR as suggested in the documentation - the automatically generated local-deploy versioning can be misleading. For example:
```
            name ready restarts              started  namespace      app_version
bl01c-di-dcam-01  true        2 2024-02-20T12:57:59Z b01-1-iocs         2024.2.4
bl01c-di-dcam-02  true        0 2024-02-20T10:54:02Z b01-1-iocs         2024.2.5
bl01c-ea-test-01  true        0 2024-02-20T13:16:27Z b01-1-iocs         2024.2.6
 bl01c-mo-ioc-01  true        0 2024-02-22T16:53:24Z b01-1-iocs 2024.2.5-b16.52
      epics-opis  true        0 2024-02-19T14:30:17Z b01-1-iocs         2024.2.4
```
One might confuse that the `2024.2.5-b16.52` tag is a local edit of the repository at`2024.2.5` however it follows a YYYY.MM.DD convention which could be said to be inconsistent with the suggested versioning.

This PR introduces the following for `ec deploy_local`
- A YYYY.MM.MINOR-b scheme where MINOR is derived from the base 32 representation of the Day.hour.minute.seconds
- This also addresses the current clash of version name for deploying multiple times within one minute (by including seconds) but still reduces the length of the version

An example of the new output is
```
            name ready restarts              started  namespace   app_version
bl01c-di-dcam-01  true        2 2024-02-20T12:57:59Z b01-1-iocs      2024.2.4
bl01c-di-dcam-02  true        0 2024-02-20T10:54:02Z b01-1-iocs      2024.2.5
bl01c-ea-test-01  true        0 2024-02-20T13:16:27Z b01-1-iocs      2024.2.6
 bl01c-mo-ioc-01  true        0 2024-02-27T16:28:43Z b01-1-iocs 2024.2.1PSC-b
      epics-opis  true        0 2024-02-19T14:30:17Z b01-1-iocs      2024.2.4
```

