### PR TITLE
Service versions: Capture missing commits between tags

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,14 @@ def mock_run(mocker):
         "edge_containers_cli.globals.EC_DEBUG",
         "1",
     )
+    mocker.patch(
+        "edge_containers_cli.globals.CACHE_ROOT",
+        TMPDIR,
+    )
+    mocker.patch(
+        "edge_containers_cli.globals.CACHE_EXPIRY",
+        0,
+    )
 
     # Patch functions
     mocker.patch("webbrowser.open", MOCKRUN._str_command)
@@ -163,10 +171,8 @@ def data() -> Path:
 @fixture()
 def ctx():
     ctx = Context
-    # TODO - are these required now the namespace is flat ?
     ctx.parent = Context  # type: ignore
-    ctx.parent.parent = Context  # type: ignore
-    ctx.parent.parent.params = {}  # type: ignore
+    ctx.parent.params = {}  # type: ignore
     return ctx
 
 

--- a/tests/data/autocomplete.yaml
+++ b/tests/data/autocomplete.yaml
@@ -30,13 +30,12 @@ avail_versions:
     rsp: Cloning into /tmp/xxxx...
   - cmd: git tag
     rsp: |
+      1.0
       2.0
-  - cmd: git ls-tree -r 2.0 --name-only
-    rsp: |
-      2.0
-  - cmd: git diff --name-only 2.0 2.0\^
-    rsp: |
-      2.0 bl45p-ea-ioc-01
+  - cmd: git ls-tree -r 1.0 --name-only
+    rsp: bl45p-ea-ioc-01
+  - cmd: git diff --name-only 1.0 2.0
+    rsp: bl45p-ea-ioc-01
 
 running_iocs:
   - cmd: kubectl get namespace bl45p -o name

--- a/tests/data/ioc.yaml
+++ b/tests/data/ioc.yaml
@@ -42,13 +42,12 @@ instances:
     rsp: Cloning into /tmp/xxxx...
   - cmd: git tag
     rsp: |
+      1.0
       2.0
-  - cmd: git ls-tree -r 2.0 --name-only
-    rsp: |
-      2.0
-  - cmd: git diff --name-only 2.0 2.0\^
-    rsp: |
-      2.0 bl45p-ea-ioc-01
+  - cmd: git ls-tree -r 1.0 --name-only
+    rsp: bl45p-ea-ioc-01
+  - cmd: git diff --name-only 1.0 2.0
+    rsp: bl45p-ea-ioc-01
 
 exec:
   - cmd: kubectl -it -n bl45p exec statefulset/bl45p-ea-ioc-01 -- bash

--- a/tests/data/local.yaml
+++ b/tests/data/local.yaml
@@ -68,13 +68,12 @@ instances:
     rsp: Cloning into /tmp/xxxx...
   - cmd: git tag
     rsp: |
+      1.0
       2.0
-  - cmd: git ls-tree -r 2.0 --name-only
-    rsp: |
-      2.0
-  - cmd: git diff --name-only 2.0 2.0\^
-    rsp: |
-      2.0
+  - cmd: git ls-tree -r 1.0 --name-only
+    rsp: bl45p-ea-ioc-01
+  - cmd: git diff --name-only 1.0 2.0
+    rsp: bl45p-ea-ioc-01
 
 exec:
   - cmd: docker ps -f name=bl45p-ea-ioc-01 --format .*

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -41,6 +41,7 @@ def test_all_iocs_local(mock_run, mocker, autocomplete, ctx):
 
 def test_avail_IOCs(mock_run, data, autocomplete, ctx):
     mock_run.set_seq(autocomplete.avail_IOCs)
+    TMPDIR.mkdir()
     shutil.copytree(data / "services", TMPDIR / "services")
 
     ctx.parent.parent.params["repo"] = ""  # use env variable
@@ -50,12 +51,13 @@ def test_avail_IOCs(mock_run, data, autocomplete, ctx):
 
 def test_avail_versions(mock_run, data, autocomplete, ctx):
     mock_run.set_seq(autocomplete.avail_versions)
-    # shutil.copytree(data / "services", TMPDIR / "services") already exists
+    TMPDIR.mkdir()
+    shutil.copytree(data / "services", TMPDIR / "services")
 
     ctx.parent.parent.params["repo"] = ""  # use env variable
     ctx.parent.parent.params["service_name"] = "bl45p-ea-ioc-01"
     result = mock_run.call(avail_versions, ctx)
-    assert result == ["2.0"]
+    assert result == ["1.0", "2.0"]
 
 
 def test_running_iocs(mock_run, autocomplete, ctx):

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -18,7 +18,7 @@ from tests.conftest import TMPDIR
 def test_all_iocs(mock_run, autocomplete, ctx):
     mock_run.set_seq(autocomplete.all_iocs)
 
-    ctx.parent.parent.params["namespace"] = ""  # use env variable
+    ctx.parent.params["namespace"] = ""  # use env variable
     result = mock_run.call(all_svc, ctx)
     assert result == ["bl45p-ea-ioc-01"]
 
@@ -34,7 +34,7 @@ def test_all_iocs_local(mock_run, mocker, autocomplete, ctx):
     )
     mock_run.set_seq(autocomplete.all_iocs_local)
 
-    ctx.parent.parent.params["namespace"] = ""  # use env variable
+    ctx.parent.params["namespace"] = ""  # use env variable
     result = mock_run.call(all_svc, ctx)
     assert result == ["bl45p-ea-ioc-01"]
 
@@ -44,7 +44,7 @@ def test_avail_IOCs(mock_run, data, autocomplete, ctx):
     TMPDIR.mkdir()
     shutil.copytree(data / "services", TMPDIR / "services")
 
-    ctx.parent.parent.params["repo"] = ""  # use env variable
+    ctx.parent.params["repo"] = ""  # use env variable
     result = mock_run.call(avail_services, ctx)
     assert result == ["bl45p-ea-ioc-01"]
 
@@ -54,8 +54,8 @@ def test_avail_versions(mock_run, data, autocomplete, ctx):
     TMPDIR.mkdir()
     shutil.copytree(data / "services", TMPDIR / "services")
 
-    ctx.parent.parent.params["repo"] = ""  # use env variable
-    ctx.parent.parent.params["service_name"] = "bl45p-ea-ioc-01"
+    ctx.parent.params["repo"] = ""  # use env variable
+    ctx.parent.params["service_name"] = "bl45p-ea-ioc-01"
     result = mock_run.call(avail_versions, ctx)
     assert result == ["1.0", "2.0"]
 
@@ -63,7 +63,7 @@ def test_avail_versions(mock_run, data, autocomplete, ctx):
 def test_running_iocs(mock_run, autocomplete, ctx):
     mock_run.set_seq(autocomplete.running_iocs)
 
-    ctx.parent.parent.params["namespace"] = ""  # use env variable
+    ctx.parent.params["namespace"] = ""  # use env variable
     result = mock_run.call(running_svc, ctx)
     assert result == ["bl45p-ea-ioc-01"]
 
@@ -79,6 +79,6 @@ def test_running_iocs_local(mock_run, mocker, autocomplete, ctx):
     )
     mock_run.set_seq(autocomplete.running_iocs_local)
 
-    ctx.parent.parent.params["namespace"] = ""  # use env variable
+    ctx.parent.params["namespace"] = ""  # use env variable
     result = mock_run.call(running_svc, ctx)
     assert result == ["bl45p-ea-ioc-01"]


### PR DESCRIPTION

This PR addresses the following issues regarding determining the "version" of a service:
- Missing commits in-between tags

1. Consider a git history 
```
[esq51579@pc0146 bl01c]$ git log --oneline
d4346da (tag: 2024.2.7) Add missing axes 4, 7
b40fd8a Increase pmac velocities
8569a86 update to correct ioc-pmac version
9d31ad7 update to latest ioc-pmac
5dc8b4e Add test IOC for debug                                    <-- Here a service has been added
251606b (tag: 2024.2.6) Add motion controller ioc
```

Currently we compare to the parent commit
```
[esq51579@pc0146 bl01c]$ git log 2024.2.7...2024.2.7^ --oneline
d4346da (tag: 2024.2.7) Add missing axes 4, 7
```

Therefore we miss commits in-between tags and do not capture the added service. It is proposed to compare across tags:
```
[esq51579@pc0146 bl01c]$ git log 2024.2.7...2024.2.6 --oneline
d4346da (tag: 2024.2.7) Add missing axes 4, 7
b40fd8a Increase pmac velocities
8569a86 update to correct ioc-pmac version
9d31ad7 update to latest ioc-pmac
5dc8b4e Add test IOC for debug
```

A question is then how to choose which is the reference tag.
Tags are returned and then compared in lexicographic order which is not desirable
```
[esq51579@pc0146 bl01c]$ git tag
2024.2.1
2024.2.10
2024.2.2
2024.2.3
2024.2.4
2024.2.5
2024.2.6
2024.2.7
2024.2.8
2024.2.9
```

It is proposed to rather sort in order of the commit date
```
[esq51579@pc0146 bl01c]$ git tag --sort=committerdate
2024.2.1
2024.2.2
2024.2.3
2024.2.4
2024.2.5
2024.2.6
2024.2.7
2024.2.8
2024.2.9
2024.2.10
```