### PR TITLE
remove code from old cli namespaces

### DIFF
--- a/src/edge_containers_cli/cmds/k8s_commands.py
+++ b/src/edge_containers_cli/cmds/k8s_commands.py
@@ -72,7 +72,6 @@ class K8sCommands:
     ):
         self.namespace: str = ""
         self.beamline_repo: str = ""
-        self.service_type: str = ""
         # TODO isnt ctx always set??
         if ctx is not None:
             namespace = ctx.namespace

--- a/src/edge_containers_cli/cmds/local_commands.py
+++ b/src/edge_containers_cli/cmds/local_commands.py
@@ -75,7 +75,7 @@ class LocalCommands:
         self.docker.remove(self.service_name)
 
     def _do_deploy(self, ioc_instance: Path, version: str, args: str):
-        service_name, ioc_path = check_instance_path(ioc_instance)
+        service_name, _ = check_instance_path(ioc_instance)
 
         image = get_instance_image_name(ioc_instance)
         log.debug(f"deploying {ioc_instance} with image {image}")

--- a/src/edge_containers_cli/docker.py
+++ b/src/edge_containers_cli/docker.py
@@ -3,22 +3,14 @@ Utility functions for working interacting with docker / podman CLI
 """
 
 import re
-import sys
 from pathlib import Path
 from time import sleep
-from typing import Optional
 
 import typer
 
 import edge_containers_cli.globals as globals
 import edge_containers_cli.shell as shell
 from edge_containers_cli.logging import log
-
-IMAGE_TAG = "local"
-MOUNTED_FILES = ["/.bashrc", "/.inputrc", "/.bash_eternal_history"]
-
-# podman needs this security option to allow containers to mount tmp etc.
-PODMAN_OPT = " --security-opt=label=type:container_runtime_t"
 
 
 class Docker:
@@ -66,47 +58,6 @@ class Docker:
         self.is_buildx = "docker/buildx" in str(result)
 
         log.debug(f"buildx={self.is_buildx} ({result})")
-
-    def _all_params(
-        self, args: str, mounts: Optional[list[Path]] = None, exec: bool = False
-    ):
-        """
-        set up parameters for call to docker/podman
-        """
-        opts = PODMAN_OPT if not self.is_docker and not exec else ""
-
-        if self.devcontainer:
-            if sys.stdin.isatty():
-                # interactive
-                env = "-e DISPLAY -e SHELL -e TERM -it"
-            else:
-                env = "-e DISPLAY -e SHELL"
-
-            volumes = ""
-            for file in MOUNTED_FILES:
-                file_path = Path(file)
-                if file_path.exists():
-                    volumes += f" -v {file}:/root/{file_path.name}"
-            if mounts is not None:
-                for mount in mounts:
-                    volumes += f" -v {mount}"
-
-            log.debug(f"env={env} volumes={volumes} opts={opts}")
-
-            params = f"{env}{opts}{volumes}" + f" {args}" if args else ""
-        else:
-            params = f"{opts}" + (f"{args}" if args else "")
-
-        return params
-
-    def run(self, name: str, args: str = "", mounts: Optional[list[Path]] = None):
-        """
-        run a command in a local container
-        """
-        params = self._all_params(args, mounts=mounts)
-        shell.run_command(
-            f"{self.docker} run --rm --name {name} {params}", interactive=True
-        )
 
     def exec(
         self,

--- a/src/edge_containers_cli/docker.py
+++ b/src/edge_containers_cli/docker.py
@@ -108,37 +108,6 @@ class Docker:
             f"{self.docker} run --rm --name {name} {params}", interactive=True
         )
 
-    def build(
-        self,
-        context: str,
-        name: str,
-        target: str,
-        args: str = "",
-        cache_from: str = "",
-        cache_to: str = "",
-        push: bool = False,
-        arch: globals.Architecture = globals.Architecture.linux,
-    ):
-        """
-        build a container
-        """
-        if self.is_buildx:
-            cmd = f"{self.docker} buildx"
-            shell.run_command(
-                f"{cmd} create --driver docker-container --use", interactive=False
-            )
-            args += f" --cache-from={cache_from}" if cache_from else ""
-            args += f" --cache-to={cache_to},mode=max" if cache_to else ""
-            args += " --push" if push else " --load "
-        else:
-            cmd = f"{self.docker}"
-
-        t_arch = f" --build-arg TARGET_ARCHITECTURE={arch}" if self.devcontainer else ""
-
-        shell.run_command(
-            f"{cmd} build --target {target}{t_arch} {args} -t {name} {context}"
-        )
-
     def exec(
         self,
         container: str,

--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -5,7 +5,6 @@ Utility functions for working with git
 import os
 import re
 from pathlib import Path
-from typing import Optional
 
 import typer
 
@@ -14,22 +13,6 @@ import edge_containers_cli.shell as shell
 from edge_containers_cli.logging import log
 from edge_containers_cli.shell import check_services_repo
 from edge_containers_cli.utils import chdir
-
-
-def get_image_name(
-    repo: str,
-    arch: globals.Architecture = globals.Architecture.linux,
-    target: str = "developer",
-    suffix: Optional[str] = None,
-) -> str:
-    if suffix is None:
-        suffix = "-{arch}-{target}"
-    registry = repo2registry(repo).lower()
-    img_suffix = suffix.format(repo=repo, arch=arch, target=target, registry=registry)
-
-    image = f"{registry}{img_suffix}"
-    log.info("repo = %s image  = %s", repo, image)
-    return image
 
 
 def get_git_name(folder: Path = Path(".")) -> tuple[str, Path]:

--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -3,91 +3,12 @@ Utility functions for working with git
 """
 
 import os
-import re
 from pathlib import Path
 
-import typer
-
-import edge_containers_cli.globals as globals
 import edge_containers_cli.shell as shell
 from edge_containers_cli.logging import log
 from edge_containers_cli.shell import check_services_repo
 from edge_containers_cli.utils import chdir
-
-
-def get_git_name(folder: Path = Path(".")) -> tuple[str, Path]:
-    """
-    work out the git repo name and top level folder for a local clone
-    """
-    os.chdir(folder)
-    path = str(shell.run_command("git rev-parse --show-toplevel", interactive=False))
-    git_root = Path(path.strip())
-
-    remotes = str(shell.run_command("git remote -v", interactive=False))
-    log.debug(f"remotes = {remotes}")
-
-    matches = re.findall(r"((?:(?:git@)|(?:http[s]+:\/\/)).*) (?:.fetch.)", remotes)
-
-    if len(matches) > 0:
-        repo_name = str(matches[0])
-    else:
-        log.error(f"folder {folder.absolute()} cannot parse repo name {remotes}")
-        raise typer.Exit(1)
-
-    log.debug(f"repo_name = {repo_name}, git_root = {git_root}")
-    return repo_name, git_root
-
-
-# work out what the registry name is for a given repo remote e.g.
-def repo2registry(repo_name: str) -> str:
-    """convert a repo name to the related a container registry name"""
-
-    # First try matching using the regex mappings environment variable
-    registry = ""
-    # remove .git suffix because regexes are hard to make with optional suffix
-    # not all git remotes have it for some reason
-    repo_name = repo_name.removesuffix(".git")
-
-    for mapping in globals.EC_REGISTRY_MAPPING_REGEX.split("\n"):
-        if mapping == "":
-            continue
-        regex, replacement = mapping.split(" ")
-        log.debug("regex = %s replacement = %s", regex, replacement)
-        match = re.match(regex, repo_name)
-        if match is not None:
-            registry = match.expand(replacement)
-            break
-
-    if registry:
-        return registry
-
-    # Now try matching using the simple mappings environment variable.
-    # Here automatically add the organization name to the image root URL
-    log.debug("extracting fields from repo name %s", repo_name)
-
-    match_git = re.match(r"git@([^:]*):(.*)\/(.*)", repo_name)
-    match_http = re.match(r"https:\/\/([^\/]*)\/([^\/]*)\/([^\/]*)", repo_name)
-    for match in [match_git, match_http]:
-        if match is not None:
-            source_reg, org, repo = match.groups()
-            break
-    else:
-        log.error(f"repo {repo_name} is not a valid git remote")
-        raise typer.Exit(1)
-
-    log.debug("source_reg = %s org = %s repo = %s", source_reg, org, repo)
-
-    for mapping in globals.EC_REGISTRY_MAPPING.split():
-        if mapping.split("=")[0] == source_reg:
-            registry = mapping.split("=")[1]
-            registry = f"{registry}/{org}/{repo}"
-            break
-    else:
-        log.error(f"repo {repo_name} does not match any registry mapping")
-        log.error("please update the environment variable EC_REGISTRY_MAPPING")
-        raise typer.Exit(1)
-
-    return registry
 
 
 def create_svc_graph(repo: str, folder: Path) -> dict:

--- a/src/edge_containers_cli/globals.py
+++ b/src/edge_containers_cli/globals.py
@@ -23,10 +23,6 @@ CONFIG_FOLDER = "config"
 IOC_CONFIG_FOLDER = "/epics/ioc/config/"
 # file name of IOC Instance ibek configuration inside a Generic IOC container
 CONFIG_FILE_GLOB = "*.yaml"
-# location of default IOC start script inside Generic IOC containers
-IOC_START = "/epics/ioc/start.sh"
-# default container name for local testing
-IOC_NAME = "test-ioc"
 # namespace name for deploying IOC instances into the local podman/docker
 LOCAL_NAMESPACE = "local"
 # location for caching
@@ -41,32 +37,6 @@ CACHE_EXPIRY = 15
 EC_DEBUG = bool(os.environ.get("EC_DEBUG", 0))
 # Enable printing of all shell commands run by ec
 EC_VERBOSE = bool(os.environ.get("EC_VERBOSE", 0))
-
-"""
-each mapping is a string of the form <source registry>=<container registry>
-the container registry is used to build the image name as
-<container registry>/<source organisation>/<repo name (without .git)>:<tag>
-mappings are separated by space or line break.
-
-For a much more flexible way to define mappings see EC_REGISTRY_MAPPING_REGEX
-"""
-EC_REGISTRY_MAPPING = os.environ.get(
-    "EC_REGISTRY_MAPPING",
-    "github.com=ghcr.io",
-)
-
-"""
-each mapping is a regex to match the repo name and a replacement string
-to generate the container registry name. Mappings are separated by line
-break and regex and replacement are separated by space
-"""
-EC_REGISTRY_MAPPING_REGEX = os.environ.get(
-    "EC_REGISTRY_MAPPING_REGEX",
-    r"""
-.*github.com:(.*)\/(.*) ghcr.io/\1/\2
-.*gitlab.diamond.ac.uk.*\/(.*) gcr.io/diamond-privreg/controls/prod/ioc/\1
-""",
-)
 
 EC_CONTAINER_CLI = os.environ.get("EC_CONTAINER_CLI")  # default to auto choice
 EC_SERVICES_REPO = os.environ.get("EC_SERVICES_REPO", "")

--- a/src/edge_containers_cli/globals.py
+++ b/src/edge_containers_cli/globals.py
@@ -1,6 +1,5 @@
 import os
 from dataclasses import dataclass
-from enum import Enum
 
 import polars
 
@@ -13,23 +12,6 @@ class Context:
     beamline_repo: str = ""
     verbose: bool = False
     debug: bool = False
-
-
-class Architecture(str, Enum):
-    linux = "linux"
-    rtems = "rtems"
-    arm = "arm"
-
-    def __str__(self):
-        return str(self.value)
-
-
-class Targets(str, Enum):
-    developer = "developer"
-    runtime = "runtime"
-
-    def __str__(self):
-        return str(self.value)
 
 
 # common stings used in paths


### PR DESCRIPTION
Just removed a couple of things that are holdevers from the 'dev' namespace.

In particular I'm looking at changing the container names e.g.
- ioc-pmac-linux-runtime to
- ioc-pmac-linux-x86_64-runtime

And was just checking their are no refs to container name in this CLI.