### PR TITLE
Change EC services repo for test

### DIFF
--- a/.github/workflows/_sys_test.yml
+++ b/.github/workflows/_sys_test.yml
@@ -1,15 +1,14 @@
 on:
   workflow_call:
-      inputs:
-        python-version:
-          type: string
-          description: The version of python to install
-          required: true
-        runs-on:
-          type: string
-          description: The runner to run this job on
-          required: true
-
+    inputs:
+      python-version:
+        type: string
+        description: The version of python to install
+        required: true
+      runs-on:
+        type: string
+        description: The runner to run this job on
+        required: true
 
 jobs:
   run:
@@ -17,7 +16,7 @@ jobs:
     env:
       EC_INTERACTIVE_TESTING: "true"
       EC_K8S_NAMESPACE: "default"
-      EC_SERVICES_REPO: "https://github.com/epics-containers/bl47p.git"
+      EC_SERVICES_REPO: "https://github.com/marcelldls/bl01t.git"
     steps:
       - name: start minikube
         id: minikube
@@ -31,5 +30,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           pip-install: ".[dev]"
+      - name: Set up namespace
+        run: ec deploy epics-pvcs 2024.2.1
       - name: system tests
         run: tox -e tests

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -37,7 +37,7 @@ def test_validate():
 )
 def test_deploy():
     """Test deploy"""
-    IOC = "bl47p-ea-test-01"
+    IOC = "bl01t-ea-test-01"
     runner = CliRunner()
 
     trigger = runner.invoke(
@@ -51,7 +51,7 @@ def test_deploy():
 
     assert trigger.exit_code == 0, trigger.output
 
-    time.sleep(3)  # Temporary
+    time.sleep(10)  # Temporary
     check = runner.invoke(cli, "ps")
 
     assert IOC in check.output


### PR DESCRIPTION
This PR fixes the failing deploy system test. The reason the test fails is because ec ps is used which now only shows running services. The test service was failing because:
- epics-pvcs was not deployed first -> This is now done
- bl47p-ea-test-01 was being used, which expects some additional cluster settings -> We could probably get this working but I rather used the more simple bl01t services repo

Hacky bits which should be changed:
- Using the bl01t from my namespace. Should update the one on the epics-containers org and use that
- Using sleep in the test. Should possibly implement a wait using kubectl