### PR TITLE
make ec list and instances output consistant with ps

### DIFF
--- a/src/edge_containers_cli/cmds/cli.py
+++ b/src/edge_containers_cli/cmds/cli.py
@@ -180,7 +180,6 @@ def instances(
     ),
 ):
     """List all versions of the IOC/service available in the helm registry"""
-    typer.echo(f"Available instances for {service_name}:")
     tmp_dir = Path(tempfile.mkdtemp())
     svc_graph = create_svc_graph(ctx.obj.beamline_repo, tmp_dir)
     try:
@@ -189,7 +188,8 @@ def instances(
         svc_list = []
 
     sorted_list = natsorted(svc_list)[::-1]
-    typer.echo("  ".join(sorted_list))
+    services_df = polars.from_dict({"version": sorted_list})
+    print(services_df)
 
     cleanup_temp(tmp_dir)
 


### PR DESCRIPTION
Currently we get
```
(.venv) [esq51579@pc0146 edge-containers-cli]$ ec ps
| name             | version  | running | restarts | deployed            |
|------------------|----------|---------|----------|---------------------|
| epics-opis       | 2024.2.9 | true    | 0        | 2024-02-28 15:44:42 |
| bl01c-di-dcam-01 | 2024.2.4 | true    | 0        | 2024-03-13 13:45:38 |
| bl01c-di-dcam-02 | 2024.2.5 | true    | 0        | 2024-03-13 13:46:03 |
| bl01c-ea-test-01 | 2024.2.1 | true    | 0        | 2024-03-13 13:47:03 |
| bl01c-mo-ioc-01  | 2024.3.1 | true    | 0        | 2024-03-04 12:17:03 |
[esq51579@pc0146 WIP]$ ec list
Available services:                Latest instance:
bl01c-di-dcam-01                   2024.2.4
bl01c-di-dcam-02                   2024.2.5
bl01c-ea-test-01                   2023.3.2
bl01c-ea-test-02                   2024.2.3
bl01c-ea-test-03                   2023.3.2
bl01c-mo-ioc-01                    2024.3.1
epics-opis                         2024.2.9
epics-pvcs                         2023.3.2
[esq51579@pc0146 WIP]$ ec instances bl01c-di-dcam-01
Available instances for bl01c-di-dcam-01:
2024.2.4  2023.3.2
```

This PR makes the output more consistant
```
(.venv) [esq51579@pc0146 edge-containers-cli]$ ec ps
| name             | version  | running | restarts | deployed            |
|------------------|----------|---------|----------|---------------------|
| epics-opis       | 2024.2.9 | true    | 0        | 2024-02-28 15:44:42 |
| bl01c-di-dcam-01 | 2024.2.4 | true    | 0        | 2024-03-13 13:45:38 |
| bl01c-di-dcam-02 | 2024.2.5 | true    | 0        | 2024-03-13 13:46:03 |
| bl01c-ea-test-01 | 2024.2.1 | true    | 0        | 2024-03-13 13:47:03 |
| bl01c-mo-ioc-01  | 2024.3.1 | true    | 0        | 2024-03-04 12:17:03 |
(.venv) [esq51579@pc0146 edge-containers-cli]$ ec list
| name             | version  |
|------------------|----------|
| bl01c-di-dcam-01 | 2024.2.4 |
| bl01c-di-dcam-02 | 2024.2.5 |
| bl01c-ea-test-01 | 2024.2.1 |
| bl01c-ea-test-02 | 2024.2.3 |
| bl01c-ea-test-03 | 2024.2.7 |
| bl01c-mo-ioc-01  | 2024.3.1 |
| epics-opis       | 2024.2.9 |
| epics-pvcs       | 2024.2.1 |
(.venv) [esq51579@pc0146 edge-containers-cli]$ ec instances bl01c-ea-test-01
| version  |
|----------|
| 2024.2.1 |
| 2023.3.2 |
```
This format is interpretable as markdown
| name             | version  | running | restarts | deployed            |
|------------------|----------|---------|----------|---------------------|
| epics-opis       | 2024.2.9 | true    | 0        | 2024-02-28 15:44:42 |
| bl01c-di-dcam-01 | 2024.2.4 | true    | 0        | 2024-03-13 13:45:38 |
| bl01c-di-dcam-02 | 2024.2.5 | true    | 0        | 2024-03-13 13:46:03 |
| bl01c-ea-test-01 | 2024.2.1 | true    | 0        | 2024-03-13 13:47:03 |
| bl01c-mo-ioc-01  | 2024.3.1 | true    | 0        | 2024-03-04 12:17:03 |