### PR TITLE
Accomodate app.kubernetes.io/instance label

### DIFF
--- a/src/edge_containers_cli/cmds/kubectl.py
+++ b/src/edge_containers_cli/cmds/kubectl.py
@@ -1,6 +1,6 @@
 jsonpath_pod_info = (
     "-o jsonpath='"
-    r'{range .items[*]}{..labels.app}{","}{.status.phase}'
+    r'{range .items[*]}{..labels.app}{..labels.app\.kubernetes\.io/instance}{","}{.status.phase}'
     r'{","}{..containerStatuses[0].restartCount}'
     r'{"\n"}{end}'
     "'"

--- a/tests/data/bl01t/services/bl01t-ea-test-01/config/ioc.yaml
+++ b/tests/data/bl01t/services/bl01t-ea-test-01/config/ioc.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://github.com/epics-containers/ioc-adsimdetector/releases/download/2024.2.1/ibek.ioc.schema.json
+# yaml-language-server: $schema=https://github.com/epics-containers/ioc-adsimdetector/releases/download/2024.4.1/ibek.ioc.schema.json
 
 ioc_name: "{{ __utils__.get_env('IOC_NAME') }}"
 

--- a/tests/data/bl01t/services/bl01t-ea-test-01/values.yaml
+++ b/tests/data/bl01t/services/bl01t-ea-test-01/values.yaml
@@ -1,4 +1,4 @@
 # latest container image for GigE cameras from the GitHub Container Registry
 shared:
   ioc-instance:
-    image: ghcr.io/epics-containers/ioc-adsimdetector-linux-runtime:2024.2.1
+    image: ghcr.io/epics-containers/ioc-adsimdetector-runtime:2024.4.1

--- a/tests/data/local.yaml
+++ b/tests/data/local.yaml
@@ -36,7 +36,7 @@ deploy_local:
     rsp: ""
   - cmd: docker rm -f busybox
     rsp: ""
-  - cmd: docker run -dit --net host --restart unless-stopped -l is_IOC=true -l version=.* -v bl01t-ea-test-01_config:\/epics\/ioc\/config\/  --name bl01t-ea-test-01 ghcr.io\/epics-containers\/ioc-adsimdetector-linux-runtime:2024.2.1
+  - cmd: docker run -dit --net host --restart unless-stopped -l is_IOC=true -l version=.* -v bl01t-ea-test-01_config:\/epics\/ioc\/config\/  --name bl01t-ea-test-01 ghcr.io\/epics-containers\/ioc-adsimdetector-runtime:2024.4.1
     rsp: True
   - cmd: docker ps -f name=bl01t-ea-test-01 --format .*
     rsp: bl01t-ea-test-01
@@ -62,7 +62,7 @@ deploy:
     rsp: ""
   - cmd: docker rm -f busybox
     rsp: ""
-  - cmd: docker run -dit --net host --restart unless-stopped -l is_IOC=true -l version=2.0 -v bl01t-ea-test-01_config:/epics/ioc/config/  --name bl01t-ea-test-01 ghcr.io/epics-containers/ioc-adsimdetector-linux-runtime:2024.2.1
+  - cmd: docker run -dit --net host --restart unless-stopped -l is_IOC=true -l version=2.0 -v bl01t-ea-test-01_config:/epics/ioc/config/  --name bl01t-ea-test-01 ghcr.io/epics-containers/ioc-adsimdetector-runtime:2024.4.1
     rsp: True
   - cmd: docker ps -f name=bl01t-ea-test-01 --format .*
     rsp: bl01t-ea-test-01
@@ -146,5 +146,5 @@ ps:
 validate:
   - cmd: docker run --rm -w .* -v .*:.* -v \/tmp:\/tmp ghcr.io\/epics-containers\/yajsv -v .*:.* -s \/tmp\/ec_tests\/schema.json .*/bl01t-ea-test-01\/config\/ioc.yaml
     rsp: True
-  - cmd: docker manifest inspect ghcr.io\/epics-containers\/ioc-adsimdetector-linux-runtime:2024.2.1
+  - cmd: docker manifest inspect ghcr.io\/epics-containers\/ioc-adsimdetector-runtime:2024.4.1
     rsp: "OK"

--- a/tests/data/services/bl45p-ea-ioc-01/Chart.yaml
+++ b/tests/data/services/bl45p-ea-ioc-01/Chart.yaml
@@ -1,1 +1,0 @@
-# placeholder

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -27,7 +27,7 @@ def test_validate():
         ],
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Changed json path to accomodate app.kubernetes.io/instance labeling

Was:
```
[esq51579@pc0146 edge-containers-cli]$ kubectl get pods -n bl45p -o jsonpath='{range .items[*]}{..labels.app}{","}{.status.phase}{","}{..containerStatuses[
0].restartCount}{"\n"}{end}'
bl45p-mo-brick-01,Running,0
,Running,0
epics-opis,Running,0
```
Now:
```
[esq51579@pc0146 edge-containers-cli]$ kubectl get pods -n bl45p -o jsonpath='{range .items[*]}{..labels.app}{..labels.app\.kubernetes\.io/instance}{","}{.
status.phase}{","}{..containerStatuses[0].restartCount}{"\n"}{end}'
bl45p-mo-brick-01,Running,0
daq-rabbitmq,Running,0
epics-opis,Running,0
```