### PR TITLE
Resolve symlinks when checking EC service versions

### DIFF
--- a/src/edge_containers_cli/autocomplete.py
+++ b/src/edge_containers_cli/autocomplete.py
@@ -12,7 +12,7 @@ import edge_containers_cli.globals as globals
 import edge_containers_cli.shell as shell
 from edge_containers_cli.cmds.k8s_commands import check_namespace
 from edge_containers_cli.docker import Docker
-from edge_containers_cli.git import create_svc_graph
+from edge_containers_cli.git import create_version_map
 from edge_containers_cli.logging import log
 from edge_containers_cli.utils import cleanup_temp
 
@@ -46,14 +46,14 @@ def read_cached_dict(cache_folder: str, cached_file: str) -> dict:
 
 
 def fetch_service_graph(beamline_repo: str) -> dict:
-    svc_graph = read_cached_dict(url_encode(beamline_repo), globals.IOC_CACHE)
-    if not svc_graph:
+    version_map = read_cached_dict(url_encode(beamline_repo), globals.IOC_CACHE)
+    if not version_map:
         tmp_dir = Path(tempfile.mkdtemp())
-        svc_graph = create_svc_graph(beamline_repo, tmp_dir)
-        cache_dict(url_encode(beamline_repo), globals.IOC_CACHE, svc_graph)
+        version_map = create_version_map(beamline_repo, tmp_dir)
+        cache_dict(url_encode(beamline_repo), globals.IOC_CACHE, version_map)
         cleanup_temp(tmp_dir)
 
-    return svc_graph
+    return version_map
 
 
 def avail_services(ctx: typer.Context) -> list[str]:
@@ -77,8 +77,8 @@ def avail_versions(ctx: typer.Context) -> list[str]:
 
     # This block prevents getting a stack trace during autocompletion
     try:
-        svc_graph = fetch_service_graph(beamline_repo)
-        svc_versions = svc_graph[service_name]
+        version_map = fetch_service_graph(beamline_repo)
+        svc_versions = version_map[service_name]
         return svc_versions
     except KeyError:
         log.error("IOC not found")

--- a/src/edge_containers_cli/cmds/cli.py
+++ b/src/edge_containers_cli/cmds/cli.py
@@ -15,7 +15,7 @@ from edge_containers_cli.autocomplete import (
 )
 from edge_containers_cli.cmds.k8s_commands import K8sCommands
 from edge_containers_cli.cmds.local_commands import LocalCommands
-from edge_containers_cli.git import create_svc_graph
+from edge_containers_cli.git import create_version_map
 from edge_containers_cli.logging import log
 from edge_containers_cli.utils import cleanup_temp, drop_path
 
@@ -165,11 +165,11 @@ def list(
 ):
     """List all IOCs/services available in the helm registry"""
     tmp_dir = Path(tempfile.mkdtemp())
-    svc_graph = create_svc_graph(ctx.obj.beamline_repo, tmp_dir)
-    svc_list = natsorted(svc_graph.keys())
-    log.debug(f"svc_graph = {svc_graph}")
+    version_map = create_version_map(ctx.obj.beamline_repo, tmp_dir)
+    svc_list = natsorted(version_map.keys())
+    log.debug(f"version_map = {version_map}")
 
-    versions = [natsorted(svc_graph[svc])[-1] for svc in svc_list]
+    versions = [natsorted(version_map[svc])[-1] for svc in svc_list]
     services_df = polars.from_dict({"name": svc_list, "version": versions})
     print(services_df)
 
@@ -185,9 +185,9 @@ def instances(
 ):
     """List all versions of the IOC/service available in the helm registry"""
     tmp_dir = Path(tempfile.mkdtemp())
-    svc_graph = create_svc_graph(ctx.obj.beamline_repo, tmp_dir)
+    version_map = create_version_map(ctx.obj.beamline_repo, tmp_dir)
     try:
-        svc_list = svc_graph[service_name]
+        svc_list = version_map[service_name]
     except KeyError:
         svc_list = []
 

--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -29,14 +29,13 @@ def create_version_map(repo: str, folder: Path) -> dict:
     ]
     log.debug(f"service_list = {service_list}")
 
-    version_map = {service: [] for service in service_list}
+    version_map = {service_item: [] for service_item in service_list}
 
     with chdir(folder):  # From python 3.11 can use contextlib.chdir(folder)
         result_tags = str(
             shell.run_command("git tag --sort=committerdate", interactive=False)
         )
-        tags_list = result_tags.split("\n")
-        tags_list.remove("")
+        tags_list = result_tags.rstrip().split("\n")
         log.debug(f"tags_list = {tags_list}")
 
         for tag_no, _ in enumerate(tags_list):

--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -72,12 +72,12 @@ def create_version_map(repo: str, folder: Path) -> dict:
                     ## Find symlink mapping to target file
                     symlink_map = {}  # source path: target path
                     for symlink in symlink_object_map.keys():
-                        # If already retieved git object, use stored
+                        # If already retrieved git object, use stored
                         if symlink_object_map[symlink] in cached_git_obj:
                             symlink_map[symlink] = cached_git_obj[
                                 symlink_object_map[symlink]
                             ]
-                        # Else retieve git object
+                        # Else retrieve git object
                         else:
                             cmd = f"git cat-file -p {symlink_object_map[symlink]}"
                             result_symlinks = str(

--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -29,10 +29,9 @@ def create_version_map(repo: str, folder: Path) -> dict:
     ]
     log.debug(f"service_list = {service_list}")
 
-    version_map = {service:[] for service in service_list}
+    version_map = {service: [] for service in service_list}
 
     with chdir(folder):  # From python 3.11 can use contextlib.chdir(folder)
-
         result_tags = str(
             shell.run_command("git tag --sort=committerdate", interactive=False)
         )
@@ -41,7 +40,6 @@ def create_version_map(repo: str, folder: Path) -> dict:
         log.debug(f"tags_list = {tags_list}")
 
         for tag_no, _ in enumerate(tags_list):
-
             # Check initial configuration
             if not tag_no:
                 cmd = f"git ls-tree -r {tags_list[tag_no]} --name-only"
@@ -66,10 +64,11 @@ def create_version_map(repo: str, folder: Path) -> dict:
                     pass
                 else:
                     symlink_object_map = {
-                        entry.split()[-1]:entry.split()[-2] for entry in result_symlink_obj.rstrip().split("\n")
+                        entry.split()[-1]: entry.split()[-2]
+                        for entry in result_symlink_obj.rstrip().split("\n")
                     }
 
-                    ## Find symlink mapping to file               
+                    ## Find symlink mapping to file
                     symlink_map = {}
                     for symlink in symlink_object_map.keys():
                         cmd = f"git cat-file -p {symlink_object_map[symlink]}"
@@ -81,16 +80,22 @@ def create_version_map(repo: str, folder: Path) -> dict:
                     ## Group sources per target
                     target_tree = {}
                     for source, target_raw in symlink_map.items():
-                        target = str(os.path.normpath(  # Normalise path
-                            os.path.join(os.path.dirname(source), target_raw),  # resolve symlink
-                            ))
+                        target = str(
+                            os.path.normpath(  # Normalise path
+                                os.path.join(
+                                    os.path.dirname(source), target_raw
+                                ),  # resolve symlink
+                            )
+                        )
                         target_tree.setdefault(target, []).append(source)
                     log.debug(f"target_tree = {target_tree}")
 
                     ## Include symlink source directories as changes
                     for sym_target in target_tree.keys():
                         if sym_target in changed_files:
-                            changed_files = "\n".join([changed_files, *target_tree[sym_target]])
+                            changed_files = "\n".join(
+                                [changed_files, *target_tree[sym_target]]
+                            )
 
             # Test each service for changes
             for service_name in service_list:

--- a/tests/data/autocomplete.yaml
+++ b/tests/data/autocomplete.yaml
@@ -42,6 +42,9 @@ avail_versions:
     rsp: bl01t-ea-test-01
   - cmd: git diff --name-only 1.0 2.0
     rsp: bl01t-ea-test-01
+  - cmd: git ls-tree HEAD~1 -r | grep 120000
+    rsp: 120000 blob test services/bl01c-ea-test-01/Charl.yaml
+
 
 running_iocs:
   - cmd: kubectl get namespace bl01t -o name

--- a/tests/data/autocomplete.yaml
+++ b/tests/data/autocomplete.yaml
@@ -43,7 +43,7 @@ avail_versions:
   - cmd: git diff --name-only 1.0 2.0
     rsp: bl01t-ea-test-01
   - cmd: git ls-tree 2.0 -r | grep 120000
-    rsp: 120000 blob test services/bl01c-ea-test-01/Chart.yaml
+    rsp: 120000 blob test services/bl01t-ea-test-01/Chart.yaml
   - cmd: git cat-file -p test
     rsp: ../../include/iocs/templates
 

--- a/tests/data/autocomplete.yaml
+++ b/tests/data/autocomplete.yaml
@@ -42,9 +42,10 @@ avail_versions:
     rsp: bl01t-ea-test-01
   - cmd: git diff --name-only 1.0 2.0
     rsp: bl01t-ea-test-01
-  - cmd: git ls-tree HEAD~1 -r | grep 120000
-    rsp: 120000 blob test services/bl01c-ea-test-01/Charl.yaml
-
+  - cmd: git ls-tree 2.0 -r | grep 120000
+    rsp: 120000 blob test services/bl01c-ea-test-01/Chart.yaml
+  - cmd: git cat-file -p test
+    rsp: ../../include/iocs/templates
 
 running_iocs:
   - cmd: kubectl get namespace bl01t -o name

--- a/tests/data/ioc.yaml
+++ b/tests/data/ioc.yaml
@@ -53,7 +53,7 @@ instances:
   - cmd: git diff --name-only 1.0 2.0
     rsp: bl01t-ea-test-01
   - cmd: git ls-tree 2.0 -r | grep 120000
-    rsp: 120000 blob test services/bl01c-ea-test-01/Chart.yaml
+    rsp: 120000 blob test services/bl01t-ea-test-01/Chart.yaml
   - cmd: git cat-file -p test
     rsp: ../../include/iocs/templates
 

--- a/tests/data/ioc.yaml
+++ b/tests/data/ioc.yaml
@@ -52,6 +52,10 @@ instances:
     rsp: bl01t-ea-test-01
   - cmd: git diff --name-only 1.0 2.0
     rsp: bl01t-ea-test-01
+  - cmd: git ls-tree 2.0 -r | grep 120000
+    rsp: 120000 blob test services/bl01c-ea-test-01/Chart.yaml
+  - cmd: git cat-file -p test
+    rsp: ../../include/iocs/templates
 
 exec:
   - cmd: kubectl -it -n bl01t exec statefulset/bl01t-ea-test-01 -- bash

--- a/tests/data/local.yaml
+++ b/tests/data/local.yaml
@@ -79,7 +79,7 @@ instances:
   - cmd: git diff --name-only 1.0 2.0
     rsp: bl01t-ea-test-01
   - cmd: git ls-tree 2.0 -r | grep 120000
-    rsp: 120000 blob test services/bl01c-ea-test-01/Chart.yaml
+    rsp: 120000 blob test services/bl01t-ea-test-01/Chart.yaml
   - cmd: git cat-file -p test
     rsp: ../../include/iocs/templates
 

--- a/tests/data/local.yaml
+++ b/tests/data/local.yaml
@@ -78,6 +78,10 @@ instances:
     rsp: bl01t-ea-test-01
   - cmd: git diff --name-only 1.0 2.0
     rsp: bl01t-ea-test-01
+  - cmd: git ls-tree 2.0 -r | grep 120000
+    rsp: 120000 blob test services/bl01c-ea-test-01/Chart.yaml
+  - cmd: git cat-file -p test
+    rsp: ../../include/iocs/templates
 
 exec:
   - cmd: docker ps -f name=bl01t-ea-test-01 --format .*

--- a/tests/data/local.yaml
+++ b/tests/data/local.yaml
@@ -30,9 +30,10 @@ deploy_local:
     rsp: ""
   - cmd: docker container create --name busybox -v bl01t-ea-test-01_config:/copyto busybox
     rsp: ""
-  - cmd: docker cp {data}/bl01t/services/bl01t-ea-test-01/config/ioc.db busybox:copyto
+  # order of globbing of files may be non-deterministic so use ioc.*
+  - cmd: docker cp {data}/bl01t/services/bl01t-ea-test-01/config/ioc.* busybox:copyto
     rsp: ""
-  - cmd: docker cp {data}/bl01t/services/bl01t-ea-test-01/config/ioc.yaml busybox:copyto
+  - cmd: docker cp {data}/bl01t/services/bl01t-ea-test-01/config/ioc.* busybox:copyto
     rsp: ""
   - cmd: docker rm -f busybox
     rsp: ""
@@ -56,9 +57,10 @@ deploy:
     rsp: ""
   - cmd: docker container create --name busybox -v bl01t-ea-test-01_config:/copyto busybox
     rsp: ""
-  - cmd: docker cp /tmp/ec_tests/services/bl01t-ea-test-01/config/ioc.db busybox:copyto
+  # order of globbing of files may be non-deterministic so use ioc.*
+  - cmd: docker cp /tmp/ec_tests/services/bl01t-ea-test-01/config/ioc.* busybox:copyto
     rsp: ""
-  - cmd: docker cp /tmp/ec_tests/services/bl01t-ea-test-01/config/ioc.yaml busybox:copyto
+  - cmd: docker cp /tmp/ec_tests/services/bl01t-ea-test-01/config/ioc.* busybox:copyto
     rsp: ""
   - cmd: docker rm -f busybox
     rsp: ""


### PR DESCRIPTION
Fixes #127  - This PR introduces the following to `ec instances`:
-  Any symlink is now considered to have had changes if the target has had changes
- A performance improvement (Roughly 2s down to 1s when using bl01c) by reducing calls to git. This is a nice reduction in latency which is good for autocompletion
- `svc_graph` is renamed to `version_map` because its more representative 