### PR TITLE
Deploy by name

### DIFF
--- a/src/edge_containers_cli/cmds/helm.py
+++ b/src/edge_containers_cli/cmds/helm.py
@@ -92,8 +92,7 @@ class Helm:
 
         with chdir(service_folder):
             shell.run_command(
-                f"helm dependency update {service_folder}; "
-                f"helm package {service_folder} --app-version {self.version}",
+                f"helm package {service_folder} -u --app-version {self.version}",
                 interactive=False,
             )
             # find the packaged chart

--- a/src/edge_containers_cli/cmds/helm.py
+++ b/src/edge_containers_cli/cmds/helm.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+from ruamel.yaml import YAML
 
 import edge_containers_cli.globals as globals
 import edge_containers_cli.shell as shell
@@ -95,11 +96,16 @@ class Helm:
                 f"helm package {service_folder} -u --app-version {self.version}",
                 interactive=False,
             )
-            # find the packaged chart
-            chart_file = list(service_folder.glob("*.tgz"))[0]
+
+            # Determine package name
+            with open("Chart.yaml") as fp:
+                chart_yaml = YAML(typ="safe").load(fp)
+            package_path = (
+                service_folder / f'{chart_yaml["name"]}-{chart_yaml["version"]}.tgz'
+            )
 
         # use helm to install the chart
-        self._install(chart_file)
+        self._install(package_path)
 
     def _install(self, helm_chart: Path):
         """

--- a/tests/data/ioc.yaml
+++ b/tests/data/ioc.yaml
@@ -17,7 +17,7 @@ template:
     rsp: ""
   - cmd: 'helm package .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01 -u --app-version .*'
     rsp: ""
-  - cmd: 'bash -c "helm template bl01t-ea-test-01 .*pretend_helm.tgz --namespace bl01t  --debug'
+  - cmd: 'bash -c "helm template bl01t-ea-test-01 .*\.tgz --namespace bl01t  --debug *'
     rsp: |
       # Source: bl01t-ea-test-01/templates/configmap.yaml
       apiVersion: v1
@@ -28,7 +28,7 @@ deploy_local:
     rsp: ""
   - cmd: 'helm package .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01 -u --app-version .*'
     rsp: ""
-  - cmd: 'bash -c "helm upgrade --install bl01t-ea-test-01 .*pretend_helm.tgz --namespace bl01t'
+  - cmd: 'bash -c "helm upgrade --install bl01t-ea-test-01 .*\.tgz --namespace bl01t *'
     rsp: ""
 
 deploy:
@@ -38,7 +38,7 @@ deploy:
     rsp: ""
   - cmd: helm package /tmp/ec_tests/services/bl01t-ea-test-01 -u --app-version 2.0
     rsp: ""
-  - cmd: 'bash -c "helm upgrade --install bl01t-ea-test-01 .*pretend_helm.tgz --namespace bl01t.*'
+  - cmd: 'bash -c "helm upgrade --install bl01t-ea-test-01 .*\.tgz --namespace bl01t *'
     rsp: ""
 
 instances:

--- a/tests/data/ioc.yaml
+++ b/tests/data/ioc.yaml
@@ -15,7 +15,7 @@ delete:
 template:
   - cmd: 'helm dependency update .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01\/..\/..\/helm\/shared'
     rsp: ""
-  - cmd: 'helm dependency update .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01\; helm package .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01 --app-version .*'
+  - cmd: 'helm package .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01 -u --app-version .*'
     rsp: ""
   - cmd: 'bash -c "helm template bl01t-ea-test-01 .*pretend_helm.tgz --namespace bl01t  --debug'
     rsp: |
@@ -26,7 +26,7 @@ template:
 deploy_local:
   - cmd: 'helm dependency update .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01\/..\/..\/helm\/shared'
     rsp: ""
-  - cmd: 'helm dependency update .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01\; helm package .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01 --app-version .*'
+  - cmd: 'helm package .*\/tests\/data\/bl01t\/services\/bl01t-ea-test-01 -u --app-version .*'
     rsp: ""
   - cmd: 'bash -c "helm upgrade --install bl01t-ea-test-01 .*pretend_helm.tgz --namespace bl01t'
     rsp: ""
@@ -36,7 +36,7 @@ deploy:
     rsp: namespace/bl01t
   - cmd: git clone https://github.com/epics-containers/bl01t /tmp/ec_tests --depth=1 --single-branch --branch=2.0
     rsp: ""
-  - cmd: helm dependency update /tmp/ec_tests/services/bl01t-ea-test-01; helm package /tmp/ec_tests/services/bl01t-ea-test-01 --app-version 2.0
+  - cmd: helm package /tmp/ec_tests/services/bl01t-ea-test-01 -u --app-version 2.0
     rsp: ""
   - cmd: 'bash -c "helm upgrade --install bl01t-ea-test-01 .*pretend_helm.tgz --namespace bl01t.*'
     rsp: ""


### PR DESCRIPTION
This PR resolves #114 by doing a `template` or `deploy-local` using chart name (as per https://v2.helm.sh/docs/developing_charts/#charts-and-versioning) rather than `*.tgz`. The information is extracted from Chart.yaml

This is tested using `ec template` and checking for expected changes against:
- Changes to the `shared` charts dependency (this is picked up by `helm package -u)`
- Changes to `ioc-instance` versions (Chart.yaml) and changes to chart config (ioc.yaml)
