### PR TITLE
Swap argocd target from project to apps namespace

### DIFF
--- a/src/edge_containers_cli/__main__.py
+++ b/src/edge_containers_cli/__main__.py
@@ -56,7 +56,7 @@ def main(
         ECContext().target,
         "-t",
         "--target",
-        help="K8S namespace or ARGOCD <project>/<root-app>",
+        help="K8S namespace or ARGOCD app-namespace/root-app",
         envvar=ENV.target.value,
     ),
     backend: ECBackends = typer.Option(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,7 +206,7 @@ def ARGOCD(mocker, data):
         os.environ,
         {
             "EC_LOG_URL": "https://graylog2.diamond.ac.uk/{service_name}*",
-            "EC_TARGET": "project/bl01t",
+            "EC_TARGET": "namespace/bl01t",
             "EC_CLI_BACKEND": "ARGOCD",
         },
     )

--- a/tests/data/argocd.yaml
+++ b/tests/data/argocd.yaml
@@ -1,7 +1,7 @@
 checks:
-  - cmd: argocd app get project/bl01t
+  - cmd: argocd app get namespace/bl01t
     rsp: ""
-  - cmd: argocd app list -l "ec_service=true" --project project -o yaml
+  - cmd: argocd app list -l "ec_service=true" --app-namespace namespace -o yaml
     rsp: |
       - metadata:
           creationTimestamp: "2024-07-12T13:42:50Z"
@@ -13,7 +13,7 @@ checks:
           resources:
             - kind: StatefulSet
               name: bl01t-ea-test-01
-  - cmd: argocd app manifests project/bl01t-ea-test-01 --source live
+  - cmd: argocd app manifests namespace/bl01t-ea-test-01 --source live
     rsp: |
       ---
       apiVersion: apps/v1
@@ -25,7 +25,7 @@ checks:
         readyReplicas: 1
 
 logs:
-  - cmd: argocd app logs project/bl01t-ea-test-01
+  - cmd: argocd app logs namespace/bl01t-ea-test-01
     rsp: ""
 
 log_history:
@@ -33,13 +33,13 @@ log_history:
     rsp: True
 
 restart:
-  - cmd: argocd app delete-resource project/bl01t-ea-test-01 --kind StatefulSet
+  - cmd: argocd app delete-resource namespace/bl01t-ea-test-01 --kind StatefulSet
     rsp: ""
 
 start:
-  - cmd: argocd app set project/bl01t-ea-test-01 -p global.enabled=true
+  - cmd: argocd app set namespace/bl01t-ea-test-01 -p global.enabled=true
     rsp: ""
 
 stop:
-  - cmd: argocd app set project/bl01t-ea-test-01 -p global.enabled=false
+  - cmd: argocd app set namespace/bl01t-ea-test-01 -p global.enabled=false
     rsp: ""


### PR DESCRIPTION
It was thought that the argocd apps are prefixed by an Argocd project name - But rather they are prefixed by the app namespace name. Was not a problem because they have been the same in development.