### PR TITLE
Handle missing sts manifests after restart

### DIFF
--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -104,6 +104,8 @@ class ArgoCommands(Commands):
                     )
                     for resource_manifest in mani_resp.split("---")[1:]:
                         manifest = YAML(typ="safe").load(resource_manifest)
+                        if not manifest:
+                            continue
                         kind = manifest["kind"]
                         resource_name = manifest["metadata"]["name"]
                         if kind == "StatefulSet" and resource_name == name:


### PR DESCRIPTION
With argocd the api has forced us to use deletion of sts as the mechanism for restart (pod not exposed). Therefore, for a brief moment in time the sts manifest is null. The resulting error when trying to read the metadata freezes the tui. This handles that case.