### PR TITLE
Swap stop/start to use "temp" as default behavior

### DIFF
--- a/src/edge_containers_cli/cli.py
+++ b/src/edge_containers_cli/cli.py
@@ -234,13 +234,13 @@ def start(
     service_name: str = typer.Argument(
         ..., help="Name of the service container to start", autocompletion=all_svc
     ),
-    temp: bool = typer.Option(False, help="Directly overrides the controller values"),
+    commit: bool = typer.Option(False, help="Commits the values to the git repo"),
 ):
     """Start a service"""
     try:
-        backend.commands.start(service_name, temp)
+        backend.commands.start(service_name, commit)
     except GitError as e:
-        msg = f"{str(e)} - Try 'ec start <service> --temp' to bypass the git server"
+        msg = f"{str(e)} - Commit failed. Try 'ec start <service> --no-commit to set values without updating git"
         raise GitError(msg) from e
 
 
@@ -251,13 +251,13 @@ def stop(
         help="Name of the service container to stop",
         autocompletion=running_svc,
     ),
-    temp: bool = typer.Option(False, help="Directly overrides the controller values"),
+    commit: bool = typer.Option(False, help="Commits the values to the git repo"),
 ):
     """Stop a service"""
     try:
-        backend.commands.stop(service_name, temp)
+        backend.commands.stop(service_name, commit)
     except GitError as e:
-        msg = f"{str(e)} - Try ec stop <service> --temp to bypass the git server"
+        msg = f"{str(e)} - Commit failed. Try ec stop <service> --no-commit to set values without updating git"
         raise GitError(msg) from e
 
 

--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -84,19 +84,19 @@ class ArgoCommands(Commands):
         )
         shell.run_command(cmd, skip_on_dryrun=True)
 
-    def start(self, service_name, temp):
+    def start(self, service_name, commit):
         self._check_service(service_name)
-        if temp:
-            patch_value(self.target, f"ec_services.{service_name}.enabled", True)
-        else:
+        if commit:
             push_value(self.target, f"ec_services.{service_name}.enabled", True)
-
-    def stop(self, service_name, temp):
-        self._check_service(service_name)
-        if temp:
-            patch_value(self.target, f"ec_services.{service_name}.enabled", False)
         else:
+            patch_value(self.target, f"ec_services.{service_name}.enabled", True)
+
+    def stop(self, service_name, commit):
+        self._check_service(service_name)
+        if commit:
             push_value(self.target, f"ec_services.{service_name}.enabled", False)
+        else:
+            patch_value(self.target, f"ec_services.{service_name}.enabled", False)
 
     def _get_logs(self, service_name, prev) -> str:
         namespace, app = extract_ns_app(self.target)

--- a/src/edge_containers_cli/cmds/commands.py
+++ b/src/edge_containers_cli/cmds/commands.py
@@ -39,7 +39,7 @@ class Commands(ABC):
     Methods not exposed to the CLI should be private
     """
 
-    params_opt_out: dict[str, list[str]] = {}
+    params_opt_out: dict[str, list[str]] = {}  # Optionally drop parameters from the CLI
 
     def __init__(self, ctx: ECContext):
         self._target = ctx.target
@@ -103,11 +103,11 @@ class Commands(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def start(self, service_name: str, temp: bool) -> None:
+    def start(self, service_name: str, commit: bool) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def stop(self, service_name: str, temp: bool) -> None:
+    def stop(self, service_name: str, commit: bool) -> None:
         raise NotImplementedError
 
     def template(self, svc_instance: Path, args: str) -> None:

--- a/src/edge_containers_cli/cmds/demo_commands.py
+++ b/src/edge_containers_cli/cmds/demo_commands.py
@@ -87,7 +87,7 @@ class DemoCommands(Commands):
         self.start(service_name, False)
 
     @demo_message
-    def start(self, service_name, temp):
+    def start(self, service_name, commit):
         self._check_service(service_name)
         time.sleep(DELAY)
         self._stateDF = self._stateDF.with_columns(
@@ -98,7 +98,7 @@ class DemoCommands(Commands):
         )
 
     @demo_message
-    def stop(self, service_name, temp):
+    def stop(self, service_name, commit):
         self._check_service(service_name)
         time.sleep(DELAY)
         self._stateDF = self._stateDF.with_columns(

--- a/src/edge_containers_cli/cmds/k8s_commands.py
+++ b/src/edge_containers_cli/cmds/k8s_commands.py
@@ -24,8 +24,8 @@ class K8sCommands(Commands):
     """
 
     params_opt_out = {
-        "stop": ["temp"],
-        "start": ["temp"],
+        "stop": ["commit"],
+        "start": ["commit"],
     }
 
     def __init__(
@@ -89,14 +89,14 @@ class K8sCommands(Commands):
             f"kubectl delete -n {self.target} {pod_name}", skip_on_dryrun=True
         )
 
-    def start(self, service_name, temp):
+    def start(self, service_name, commit):
         self._check_service(service_name)
         shell.run_command(
             f"kubectl scale -n {self.target} statefulset {service_name} --replicas=1",
             skip_on_dryrun=True,
         )
 
-    def stop(self, service_name, temp):
+    def stop(self, service_name, commit):
         self._check_service(service_name)
         shell.run_command(
             f"kubectl scale -n {self.target} statefulset {service_name} --replicas=0 ",

--- a/tests/data/argocd.yaml
+++ b/tests/data/argocd.yaml
@@ -36,7 +36,7 @@ restart:
   - cmd: argocd app delete-resource namespace/bl01t-ea-test-01 --kind StatefulSet
     rsp: ""
 
-start:
+start_commit:
   - cmd: argocd app get namespace/bl01t -o yaml
     rsp: |
       spec:
@@ -56,13 +56,13 @@ start:
   - cmd: argocd app unset namespace/bl01t -p ec_services.bl01t-ea-test-01.enabled
     rsp: ""
 
-start_temp:
+start:
   - cmd: argocd app set namespace/bl01t -p ec_services.bl01t-ea-test-01.enabled=True
     rsp: ""
   - cmd: argocd app sync namespace/bl01t --apply-out-of-sync-only
     rsp: ""
 
-stop:
+stop_commit:
   - cmd: argocd app get namespace/bl01t -o yaml
     rsp: |
       spec:
@@ -76,7 +76,7 @@ stop:
   - cmd: argocd app unset namespace/bl01t -p ec_services.bl01t-ea-test-01.enabled
     rsp: ""
 
-stop_temp:
+stop:
   - cmd: argocd app set namespace/bl01t -p ec_services.bl01t-ea-test-01.enabled=False
     rsp: ""
   - cmd: argocd app sync namespace/bl01t --apply-out-of-sync-only

--- a/tests/test_argocd.py
+++ b/tests/test_argocd.py
@@ -19,28 +19,28 @@ def test_restart(mock_run, ARGOCD):
     mock_run.run_cli("restart bl01t-ea-test-01")
 
 
-def test_start(mock_run, ARGOCD, data: Path):
-    mock_run.set_seq(ARGOCD.checks + ARGOCD.start)
+def test_start_commit(mock_run, ARGOCD, data: Path):
+    mock_run.set_seq(ARGOCD.checks + ARGOCD.start_commit)
     TMPDIR.mkdir()
     shutil.copytree(data / "bl01t-deployment/apps", TMPDIR / "apps")
+    mock_run.run_cli("start bl01t-ea-test-01 --commit")
+
+
+def test_start(mock_run, ARGOCD):
+    mock_run.set_seq(ARGOCD.checks + ARGOCD.start)
     mock_run.run_cli("start bl01t-ea-test-01")
 
 
-def test_start_temp(mock_run, ARGOCD):
-    mock_run.set_seq(ARGOCD.checks + ARGOCD.start_temp)
-    mock_run.run_cli("start bl01t-ea-test-01 --temp")
-
-
-def test_stop(mock_run, ARGOCD, data: Path):
-    mock_run.set_seq(ARGOCD.checks + ARGOCD.stop)
+def test_stop_commit(mock_run, ARGOCD, data: Path):
+    mock_run.set_seq(ARGOCD.checks + ARGOCD.stop_commit)
     TMPDIR.mkdir()
     shutil.copytree(data / "bl01t-deployment/apps", TMPDIR / "apps")
+    mock_run.run_cli("stop bl01t-ea-test-01 --commit")
+
+
+def test_stop(mock_run, ARGOCD):
+    mock_run.set_seq(ARGOCD.checks + ARGOCD.stop)
     mock_run.run_cli("stop bl01t-ea-test-01")
-
-
-def test_stop_temp(mock_run, ARGOCD):
-    mock_run.set_seq(ARGOCD.checks + ARGOCD.stop_temp)
-    mock_run.run_cli("stop bl01t-ea-test-01 --temp")
 
 
 def test_ps(mock_run, ARGOCD):


### PR DESCRIPTION
e.g:
`ec stop <ioc> --temp`  becomes `ec stop <ioc>`
`ec stop <ioc>` becomes `ec stop <ioc> --commit`
closes #167 