### PR TITLE
Handling of no services case

### DIFF
--- a/src/edge_containers_cli/cmds/monitor.py
+++ b/src/edge_containers_cli/cmds/monitor.py
@@ -304,7 +304,7 @@ class IocTable(Widget):
         for i, ioc in enumerate(self.iocs):
             ioc = {key: value for key, value in ioc.items() if key not in exclude}
             self.iocs[i] = ioc
-        self.columns = [key for key in self.iocs[0].keys() if key not in exclude]
+        self.columns = [key for key in self.iocs_df.columns if key not in exclude]
 
     def _convert_df_to_list(self, iocs_df: polars.DataFrame | list) -> list[dict]:
         if isinstance(iocs_df, polars.DataFrame):


### PR DESCRIPTION
At the moment if we `get_services` and no services are present (this can also happen when all the services are being restarted) then we raise an error `f"No ec-services found in {self.target}"`. This was OK for calling `ec ps` but would need to be handled by the monitor which calls the same function.

Here the empty dataframe is represented by an empty dataframe with a Schema which allows the various operations without needing to add guards

@gilesknap this is unchanged since we tested it on your machine