### PR TITLE
Background work

### DIFF
--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -30,30 +30,35 @@ def extract_ns_app(target: str) -> tuple[str, str]:
     return namespace, app
 
 
+def do_retry(cmd):
+    def _do_retry(*args, **kwargs):
+        max_attempts = 5
+        attempt = 1
+        sleep_time = 1
+        while attempt <= max_attempts:
+            try:
+                cmd(*args, **kwargs)
+                return None
+            except ShellError:
+                if attempt == max_attempts:
+                    log.debug(f"Retry failed after {max_attempts} attempts")
+                    raise
+                else:
+                    log.debug(f"Retry attempt {attempt} failed. Retrying...")
+                    sleep(sleep_time)
+                    attempt += 1
+
+    return _do_retry
+
+
+@do_retry
 def patch_value(target: str, key: str, value: str | bool | int):
     cmd_temp_ = f"argocd app set {target} -p {key}={value}"
     shell.run_command(cmd_temp_, skip_on_dryrun=True)
-    max_attempts = 60
-    attempt = 0
-    sleep_time = 1
-    while attempt <= max_attempts:
-        try:
-            # Sync may conflict with autosync "another operation is already in progress"
-            cmd_sync = f"argocd app sync {target} --apply-out-of-sync-only"
-            shell.run_command(cmd_sync, skip_on_dryrun=True)
-            return None
-        except ShellError as e:
-            if attempt == max_attempts:
-                message = f"Argo patch failed after {max_attempts} attempts"
-                raise ChildProcessError(message) from e
-            elif "another operation is already in progress" in str(e):
-                log.debug(f"Argo patch attempt {attempt} failed. Retrying...")
-                sleep(sleep_time)
-                attempt += 1
-            else:
-                raise
+    # Rely on argocd autosync to get the cluster into the right state
 
 
+@do_retry
 def push_value(target: str, key: str, value: str | bool | int):
     # Get source details
     app_resp = shell.run_command(
@@ -70,11 +75,12 @@ def push_value(target: str, key: str, value: str | bool | int):
         value,
     )
 
-    # Sync & release a possible patched value
-    cmd_sync = f"argocd app sync {target} --apply-out-of-sync-only"
-    shell.run_command(cmd_sync, skip_on_dryrun=True)
+    # Free a possible patched value & refresh repo
     cmd_unset = f"argocd app unset {target} -p {key}"
     shell.run_command(cmd_unset, skip_on_dryrun=True)
+    cmd_refresh = f"argocd app get {target} --refresh"
+    shell.run_command(cmd_refresh, skip_on_dryrun=True)
+    # Rely on argocd autosync to get the cluster into the right state
 
 
 class ArgoCommands(Commands):

--- a/src/edge_containers_cli/definitions.py
+++ b/src/edge_containers_cli/definitions.py
@@ -40,3 +40,4 @@ class emoji(str, Enum):
     exclaim = "\U00002755"
     check_mark = "\U00002705"
     cross_mark = "\U0000274c"
+    hour_glass = "\U000023f3c"

--- a/tests/data/argocd.yaml
+++ b/tests/data/argocd.yaml
@@ -51,15 +51,13 @@ start_commit:
     rsp: ""
   - cmd: git push
     rsp: ""
-  - cmd: argocd app sync namespace/bl01t --apply-out-of-sync-only
-    rsp: ""
   - cmd: argocd app unset namespace/bl01t -p ec_services.bl01t-ea-test-01.enabled
+    rsp: ""
+  - cmd: argocd app get namespace/bl01t --refresh
     rsp: ""
 
 start:
   - cmd: argocd app set namespace/bl01t -p ec_services.bl01t-ea-test-01.enabled=True
-    rsp: ""
-  - cmd: argocd app sync namespace/bl01t --apply-out-of-sync-only
     rsp: ""
 
 stop_commit:
@@ -71,13 +69,11 @@ stop_commit:
           path: apps
   - cmd: git clone --depth=1 https://github.com/test/example-deployment.git /tmp/ec_tests
     rsp: ""
-  - cmd: argocd app sync namespace/bl01t --apply-out-of-sync-only
-    rsp: ""
   - cmd: argocd app unset namespace/bl01t -p ec_services.bl01t-ea-test-01.enabled
+    rsp: ""
+  - cmd: argocd app get namespace/bl01t --refresh
     rsp: ""
 
 stop:
   - cmd: argocd app set namespace/bl01t -p ec_services.bl01t-ea-test-01.enabled=False
-    rsp: ""
-  - cmd: argocd app sync namespace/bl01t --apply-out-of-sync-only
     rsp: ""

--- a/tests/data/yaml.yaml
+++ b/tests/data/yaml.yaml
@@ -4,7 +4,7 @@ trunk_A:
   branch_A:
     leaf_A: 0 # Leaf comment
     leaf_B: zero
-
+  branch_B: # Empty entry
 trunk_B:
   leaf_B: true # Out of order
   leaf_A: false # Comment before space

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6,14 +6,15 @@ def test_yaml_processor_get(data):
     expect_0 = {
         "trunk_A.branch_A.leaf_A": 0,
         "trunk_A.branch_A.leaf_B": "zero",
+        "trunk_A.branch_B.non_existing": None,
         "trunk_B.leaf_A": False,
         "leaf_A": "False",
     }
     for key_0 in expect_0:
         get = processor.get_key(key_0)
         expect = expect_0[key_0]
-        assert get == expect
-        assert type(get) is type(expect)
+        assert get == expect, f"The value of {key_0} is unexpected"
+        assert type(get) is type(expect), f"The type of {key_0} is unexpected"
 
 
 def test_yaml_processor_set(data):
@@ -22,12 +23,13 @@ def test_yaml_processor_set(data):
         "trunk_A.branch_A.leaf_A": 1,
         "trunk_A.branch_A.leaf_B": "one",
         "trunk_B.leaf_A": True,
-        "trunk_B.leaf_C": True,  # insertion
+        "trunk_B.leaf_C": True,  # insertion into existing key
         "leaf_A": "True",
+        "trunk_A.branch_B.something_new": False,  # insertion into empty key
     }
     for key_1 in expect_1:
         processor.set_key(key_1, expect_1[key_1])
         get = processor.get_key(key_1)
         expect = expect_1[key_1]
-        assert get == expect
-        assert type(get) is type(expect)
+        assert get == expect, f"The value of {key_1} is unexpected"
+        assert type(get) is type(expect), f"The type of {key_1} is unexpected"


### PR DESCRIPTION
This PR does the following:
- Now calls argocd `refresh` after committed changes rather than `sync` (acts as the webhook would) which prevents collisions from multiple simultaneous calls to sync the app (argocd does not like this) and is significantly faster as it allows argo to do the sync (This approach relys on the app having autosync on which feels OK). For the same reason we no longer call `sync` after doing a `patch`
- Use built-in textual workers to do background work (poll logs, poll services, do stop/start/etc)
  - Has a built in `call_from_thread` method to schedule updates in the main thread so we can worry less about thread safety
  - Clean dismissal of widgets and exiting (joins threads, cancels tasks)
- Instead of starting a new thread for each polling cycle, we have a single polling thread for each polled item and after each cycle it calls `call_from_thread` to trigger an update to the application which is more efficient
- Implements a job queue
  - Bottle neck to a single worker to reduce clashes from unsynchronised pushes to git server/argocd. Retry logic is used in the odd case of multiple users pushing changes at once. 
  - An `hour glass` emoji is use to indicate a queued task

I have combined these changes because they can be tested/demoed best together