### PR TITLE
Fix version map

### DIFF
--- a/src/edge_containers_cli/autocomplete.py
+++ b/src/edge_containers_cli/autocomplete.py
@@ -33,7 +33,10 @@ def fetch_service_graph(repo: str) -> dict:
     if not version_map:
         with new_workdir() as path:
             version_map = create_version_map(
-                repo, Path(globals.SERVICES_DIR), path, shared=[globals.SHARED_VALUES]
+                repo,
+                Path(globals.SERVICES_DIR),
+                path,
+                shared_files=[globals.SHARED_VALUES],
             )
             cache_dict(
                 globals.CACHE_ROOT / url_encode(repo),

--- a/src/edge_containers_cli/cli.py
+++ b/src/edge_containers_cli/cli.py
@@ -171,7 +171,7 @@ def instances(
             service_name,
             backend.commands.repo,
             Path(globals.SERVICES_DIR),
-            shared=[globals.SHARED_VALUES],
+            shared_files=[globals.SHARED_VALUES],
         )
     )
 
@@ -183,7 +183,7 @@ def _list():
         list_all(
             backend.commands.repo,
             Path(globals.SERVICES_DIR),
-            shared=[globals.SHARED_VALUES],
+            shared_files=[globals.SHARED_VALUES],
         )
     )
 

--- a/src/edge_containers_cli/cmds/commands.py
+++ b/src/edge_containers_cli/cmds/commands.py
@@ -195,7 +195,7 @@ class Commands(ABC):
                 self.repo,
                 Path(globals.SERVICES_DIR),
                 path,
-                shared=[globals.SHARED_VALUES],
+                shared_files=[globals.SHARED_VALUES],
             )
         svc_list = version_map.keys()
         log.debug(f"Found the following services: {svc_list}")

--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -159,7 +159,7 @@ def create_version_map(
                 )
                 changed_files = shell.run_command(cmd).split()
 
-            cmd = f"git ls-tree {tags_list[tag_no]} -r"
+            cmd = f"git ls-tree -r {tags_list[tag_no]}"
             cmd_res = str(shell.run_command(cmd, error_OK=True))
             symlink_object_map = {}
             service_list = []

--- a/src/edge_containers_cli/git.py
+++ b/src/edge_containers_cli/git.py
@@ -3,6 +3,7 @@ Utility functions for working with git
 """
 
 import os
+import re
 from pathlib import Path
 
 import polars
@@ -15,6 +16,7 @@ from edge_containers_cli.utils import (
     YamlFileError,
     YamlTypes,
     chdir,
+    is_partial_match,
     new_workdir,
 )
 
@@ -78,8 +80,50 @@ def del_key(repo_url: str, file: Path, key: str) -> None:
             raise GitError(str(e)) from e
 
 
+def _resolve_symlinks(
+    symlink_object_map: dict[str, list[str]],
+    file_list: list[str],
+    cache: dict = {},  # noqa: B006
+):
+    """
+    Propagate changes through symlink targets to source
+    """
+    ## Find symlink source mapping to git object
+    if symlink_object_map:
+        ## Find symlink mapping to target file
+        symlink_map = {}  # source path: target path
+        for symlink in symlink_object_map.keys():
+            # If already retrieved git object, use stored
+            if symlink_object_map[symlink] in cache:
+                symlink_map[symlink] = cache[symlink_object_map[symlink]]
+            # Else retrieve git object
+            else:
+                cmd = f"git cat-file -p {symlink_object_map[symlink]}"
+                result_symlinks = str(shell.run_command(cmd))
+                symlink_map[symlink] = result_symlinks
+                cache[symlink_object_map[symlink]] = result_symlinks
+
+        ## Group sources per symlink target
+        target_tree = {}
+        for source, target_raw in symlink_map.items():
+            target = str(
+                os.path.normpath(  # Simplyfy path
+                    os.path.join(
+                        os.path.dirname(source), target_raw
+                    ),  # resolve symlink
+                )
+            )
+            target_tree.setdefault(target, []).append(source)
+        log.debug(f"target_tree = {target_tree}")
+
+        ## Include symlink source files as file changes
+        for sym_target in target_tree.keys():
+            if sym_target in file_list:
+                file_list += target_tree[sym_target]
+
+
 def create_version_map(
-    repo: str, root_dir: Path, working_dir: Path, shared: list[str] | None = None
+    repo: str, root_dir: Path, working_dir: Path, shared_files: list[str] | None = None
 ) -> dict[str, list[str]]:
     """
     return a dictionary of each subdirectory in a chosen root directory in a git
@@ -87,15 +131,9 @@ def create_version_map(
     """
     shell.run_command(f"git clone {repo} {working_dir}")
     try:
-        path_list = os.listdir(os.path.join(working_dir, root_dir))
+        os.listdir(os.path.join(working_dir, root_dir))
     except FileNotFoundError as e:
         raise GitError(f"No {root_dir} directory found") from e
-    service_list = [
-        path
-        for path in path_list
-        if os.path.isdir(os.path.join(working_dir, root_dir, path))
-    ]
-    log.debug(f"service_list = {service_list}")
 
     version_map = {}
 
@@ -112,88 +150,67 @@ def create_version_map(
             # Check initial configuration
             if not tag_no:
                 cmd = f"git ls-tree -r {tags_list[tag_no]} --name-only"
-                changed_files = str(shell.run_command(cmd))
+                changed_files = shell.run_command(cmd).split()
 
             # Check repo changes between tags
             else:
                 cmd = (
-                    f"git diff --name-only {tags_list[tag_no - 1]} {tags_list[tag_no]}"
+                    f"git diff {tags_list[tag_no - 1]} {tags_list[tag_no]} --name-only"
                 )
-                changed_files = str(shell.run_command(cmd))
+                changed_files = shell.run_command(cmd).split()
 
-                # Propagate changes through symlink target to source
-                ## Find symlink source mapping to git object
-                cmd = f"git ls-tree {tags_list[tag_no]} -r | grep 120000"
-                result_symlink_obj = str(shell.run_command(cmd, error_OK=True))
-                if not result_symlink_obj:
-                    pass
-                else:
-                    symlink_object_map = {  # source path: git object
-                        entry.split()[-1]: entry.split()[-2]
-                        for entry in result_symlink_obj.rstrip().split("\n")
-                    }
+            cmd = f"git ls-tree {tags_list[tag_no]} -r"
+            cmd_res = str(shell.run_command(cmd, error_OK=True))
+            symlink_object_map = {}
+            service_list = []
+            service_pattern = r"^services\/([^.].*)\/Chart\.yaml$"
+            for entry in cmd_res.rstrip().split("\n"):
+                line = entry.split()
+                if line[0] == "120000":  # Check if is a symlink
+                    symlink_object_map[entry.split()[-1]] = line[-2]
+                if match := re.search(service_pattern, line[-1]):  # Check service
+                    service_list.append(match.group(1))
 
-                    ## Find symlink mapping to target file
-                    symlink_map = {}  # source path: target path
-                    for symlink in symlink_object_map.keys():
-                        # If already retrieved git object, use stored
-                        if symlink_object_map[symlink] in cached_git_obj:
-                            symlink_map[symlink] = cached_git_obj[
-                                symlink_object_map[symlink]
-                            ]
-                        # Else retrieve git object
-                        else:
-                            cmd = f"git cat-file -p {symlink_object_map[symlink]}"
-                            result_symlinks = str(shell.run_command(cmd))
-                            symlink_map[symlink] = result_symlinks
-                            cached_git_obj[symlink_object_map[symlink]] = (
-                                result_symlinks
+            _resolve_symlinks(symlink_object_map, changed_files, cached_git_obj)
+
+            # Test against shared files
+            if shared_files:
+                shared_change_found = False
+                for item in shared_files:
+                    if item in changed_files:
+                        for service_name in service_list:
+                            version_map.setdefault(service_name, []).append(
+                                tags_list[tag_no]
                             )
-
-                    ## Group sources per symlink target
-                    target_tree = {}
-                    for source, target_raw in symlink_map.items():
-                        target = str(
-                            os.path.normpath(  # Simplyfy path
-                                os.path.join(
-                                    os.path.dirname(source), target_raw
-                                ),  # resolve symlink
+                            log.debug(
+                                f"Added {tags_list[tag_no]} for {service_name} after shared file change"
                             )
-                        )
-                        target_tree.setdefault(target, []).append(source)
-                    log.debug(f"target_tree = {target_tree}")
-
-                    ## Include symlink source files as file changes
-                    for sym_target in target_tree.keys():
-                        if sym_target in changed_files:
-                            changed_files = "\n".join(
-                                [changed_files, *target_tree[sym_target]]
-                            )
+                        shared_change_found = True
+                        continue
+                if shared_change_found:
+                    continue
 
             # Test each service for changes
             for service_name in service_list:
-                shared_change_found = False
-                if shared:
-                    if service_name in version_map:  # Consider shared once added
-                        for item in shared:
-                            if item in changed_files:
-                                version_map[service_name].append(tags_list[tag_no])
-                                shared_change_found = True
-                if not shared_change_found:
-                    if service_name not in version_map:
-                        version_map[service_name] = []
-                    if os.path.join(root_dir, service_name) in changed_files:
-                        version_map[service_name].append(tags_list[tag_no])
+                service_path = os.path.join(root_dir, service_name)
+                if is_partial_match(service_path, changed_files):
+                    version_map.setdefault(service_name, []).append(tags_list[tag_no])
+                    log.debug(
+                        f"Added {tags_list[tag_no]} for {service_name} after directory changes"
+                    )
+                    continue
 
     return version_map
 
 
 def list_all(
-    repo: str, root_dir: Path, shared: list[str] | None = None
+    repo: str, root_dir: Path, shared_files: list[str] | None = None
 ) -> polars.DataFrame:
     """List all services available in the service repository"""
     with new_workdir() as path:
-        version_map = create_version_map(repo, root_dir, path, shared=shared)
+        version_map = create_version_map(
+            repo, root_dir, path, shared_files=shared_files
+        )
         svc_list = natsorted(version_map.keys())
         log.debug(f"version_map = {version_map}")
 
@@ -203,10 +220,12 @@ def list_all(
 
 
 def list_instances(
-    service_name: str, repo: str, root_dir: Path, shared: list[str] | None = None
+    service_name: str, repo: str, root_dir: Path, shared_files: list[str] | None = None
 ) -> polars.DataFrame:
     with new_workdir() as path:
-        version_map = create_version_map(repo, root_dir, path, shared=shared)
+        version_map = create_version_map(
+            repo, root_dir, path, shared_files=shared_files
+        )
         try:
             svc_list = version_map[service_name]
         except KeyError:

--- a/src/edge_containers_cli/utils.py
+++ b/src/edge_containers_cli/utils.py
@@ -213,3 +213,10 @@ class YamlFile:
             curser[element] = value
 
         log.debug(f"Set '{element}' in '{key_path}' to {value}")
+
+
+def is_partial_match(query: str, target_list: list[str]) -> bool:
+    for item in target_list:
+        if query in item:
+            return True
+    return False

--- a/tests/data/argocd.yaml
+++ b/tests/data/argocd.yaml
@@ -53,23 +53,17 @@ deploy:
     rsp: |
       1.0
       2.0
-      3.0
   - cmd: git ls-tree -r 1.0 --name-only
     rsp: |
       services/bl01t-ea-test-01
-      services/bl01t-ea-test-02
-  - cmd: git diff --name-only 1.0 2.0
+  - cmd: git ls-tree -r 1.0
     rsp: |
-      services/dls-aravis
-  - cmd: git ls-tree 2.0 -r | grep 120000
-    rsp: 120000 blob test-hash services/bl01t-ea-test-02/charts/dls-aravis
-  - cmd: git cat-file -p test-hash
-    rsp: ../../dls-aravis/
-  - cmd: git diff --name-only 2.0 3.0
-    rsp: |
-      services/values.yaml
-  - cmd: git ls-tree 3.0 -r | grep 120000
+      100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
+  - cmd: git diff 1.0 2.0 --name-only
     rsp: ""
+  - cmd: git ls-tree -r 2.0
+    rsp: |
+      100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
   - cmd: argocd app get namespace/bl01t
     rsp: |
       spec:

--- a/tests/data/cli.yaml
+++ b/tests/data/cli.yaml
@@ -27,10 +27,10 @@ instances:
       100644 blob 8241e61b9613d1e14ce50640340429d1f2a8f46c    services/dls-aravis/Chart.yaml
       120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls-aravis/templates
   - cmd: git cat-file -p 367e2aae38dd9ed05fdf33636a6b81314e3fbf75
-    rsp: ../../shared/
+    rsp: ../../shared/templates
   - cmd: git diff 2.0 3.0 --name-only
     rsp: |
-      services/dls/templates
+      shared/templates
   - cmd: git ls-tree -r 3.0
     rsp: |
       100644 blob 13bcbf79241ecdb006a5a8304c5d9d8f293ddab8    services/.ioc_template/Chart.yaml

--- a/tests/data/cli.yaml
+++ b/tests/data/cli.yaml
@@ -25,7 +25,7 @@ instances:
       100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
       100644 blob c473ca76143b9b7281e5dd455dbd01fb25edae7b    services/bl01t-ea-test-02/Chart.yaml
       100644 blob 8241e61b9613d1e14ce50640340429d1f2a8f46c    services/dls-aravis/Chart.yaml
-      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls/templates
+      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls-aravis/templates
   - cmd: git cat-file -p 367e2aae38dd9ed05fdf33636a6b81314e3fbf75
     rsp: ../../shared/
   - cmd: git diff 2.0 3.0 --name-only
@@ -37,7 +37,7 @@ instances:
       100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
       100644 blob c473ca76143b9b7281e5dd455dbd01fb25edae7b    services/bl01t-ea-test-02/Chart.yaml
       100644 blob 8241e61b9613d1e14ce50640340429d1f2a8f46c    services/dls-aravis/Chart.yaml
-      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls/templates
+      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls-aravis/templates
   - cmd: git diff 3.0 4.0 --name-only
     rsp: |
       services/values.yaml
@@ -47,4 +47,4 @@ instances:
       100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
       100644 blob c473ca76143b9b7281e5dd455dbd01fb25edae7b    services/bl01t-ea-test-02/Chart.yaml
       100644 blob 8241e61b9613d1e14ce50640340429d1f2a8f46c    services/dls-aravis/Chart.yaml
-      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls/templates
+      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls-aravis/templates

--- a/tests/data/cli.yaml
+++ b/tests/data/cli.yaml
@@ -6,19 +6,45 @@ instances:
       1.0
       2.0
       3.0
+      4.0
   - cmd: git ls-tree -r 1.0 --name-only
     rsp: |
       services/bl01t-ea-test-01
       services/bl01t-ea-test-02
-  - cmd: git diff --name-only 1.0 2.0
+  - cmd: git ls-tree -r 1.0
+    rsp: |
+      100644 blob 13bcbf79241ecdb006a5a8304c5d9d8f293ddab8    services/.ioc_template/Chart.yaml
+      100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
+      100644 blob c473ca76143b9b7281e5dd455dbd01fb25edae7b    services/bl01t-ea-test-02/Chart.yaml
+  - cmd: git diff 1.0 2.0 --name-only
     rsp: |
       services/dls-aravis
-  - cmd: git ls-tree 2.0 -r | grep 120000
-    rsp: 120000 blob test-hash services/bl01t-ea-test-02/charts/dls-aravis
-  - cmd: git cat-file -p test-hash
-    rsp: ../../dls-aravis/
-  - cmd: git diff --name-only 2.0 3.0
+  - cmd: git ls-tree -r 2.0
+    rsp: |
+      100644 blob 13bcbf79241ecdb006a5a8304c5d9d8f293ddab8    services/.ioc_template/Chart.yaml
+      100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
+      100644 blob c473ca76143b9b7281e5dd455dbd01fb25edae7b    services/bl01t-ea-test-02/Chart.yaml
+      100644 blob 8241e61b9613d1e14ce50640340429d1f2a8f46c    services/dls-aravis/Chart.yaml
+      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls/templates
+  - cmd: git cat-file -p 367e2aae38dd9ed05fdf33636a6b81314e3fbf75
+    rsp: ../../shared/
+  - cmd: git diff 2.0 3.0 --name-only
+    rsp: |
+      services/dls/templates
+  - cmd: git ls-tree -r 3.0
+    rsp: |
+      100644 blob 13bcbf79241ecdb006a5a8304c5d9d8f293ddab8    services/.ioc_template/Chart.yaml
+      100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
+      100644 blob c473ca76143b9b7281e5dd455dbd01fb25edae7b    services/bl01t-ea-test-02/Chart.yaml
+      100644 blob 8241e61b9613d1e14ce50640340429d1f2a8f46c    services/dls-aravis/Chart.yaml
+      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls/templates
+  - cmd: git diff 3.0 4.0 --name-only
     rsp: |
       services/values.yaml
-  - cmd: git ls-tree 3.0 -r | grep 120000
-    rsp: ""
+  - cmd: git ls-tree -r 4.0
+    rsp: |
+      100644 blob 13bcbf79241ecdb006a5a8304c5d9d8f293ddab8    services/.ioc_template/Chart.yaml
+      100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
+      100644 blob c473ca76143b9b7281e5dd455dbd01fb25edae7b    services/bl01t-ea-test-02/Chart.yaml
+      100644 blob 8241e61b9613d1e14ce50640340429d1f2a8f46c    services/dls-aravis/Chart.yaml
+      120000 blob 367e2aae38dd9ed05fdf33636a6b81314e3fbf75    services/dls/templates

--- a/tests/data/k8s.yaml
+++ b/tests/data/k8s.yaml
@@ -49,28 +49,22 @@ deploy:
     rsp: |
       1.0
       2.0
-      3.0
   - cmd: git ls-tree -r 1.0 --name-only
     rsp: |
       services/bl01t-ea-test-01
-      services/bl01t-ea-test-02
-  - cmd: git diff --name-only 1.0 2.0
+  - cmd: git ls-tree -r 1.0
     rsp: |
-      services/dls-aravis
-  - cmd: git ls-tree 2.0 -r | grep 120000
-    rsp: 120000 blob test-hash services/bl01t-ea-test-02/charts/dls-aravis
-  - cmd: git cat-file -p test-hash
-    rsp: ../../dls-aravis/
-  - cmd: git diff --name-only 2.0 3.0
-    rsp: |
-      services/values.yaml
-  - cmd: git ls-tree 3.0 -r | grep 120000
+      100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
+  - cmd: git diff 1.0 2.0 --name-only
     rsp: ""
+  - cmd: git ls-tree -r 2.0
+    rsp: |
+      100644 blob b7b39845b55fb4d45d58ba86ef4527917877d556    services/bl01t-ea-test-01/Chart.yaml
   - cmd: kubectl get namespace bl01t
     rsp: ""
-  - cmd: git clone https://github.com/epics-containers/bl01t-services /tmp/ec_tests --depth=1 --single-branch --branch=2.0
+  - cmd: git clone https://github.com/epics-containers/bl01t-services /tmp/ec_tests --depth=1 --single-branch --branch=1.0
     rsp: ""
-  - cmd: helm package /tmp/ec_tests/services/bl01t-ea-test-01 -u --app-version 2.0
+  - cmd: helm package /tmp/ec_tests/services/bl01t-ea-test-01 -u --app-version 1.0
     rsp: ""
   - cmd: helm upgrade --install bl01t-ea-test-01 .*\.tgz --values .*values.yaml  --values .*values.yaml --namespace bl01t
     rsp: ""

--- a/tests/test_argocd.py
+++ b/tests/test_argocd.py
@@ -16,7 +16,7 @@ def test_deploy(mock_run, ARGOCD, data: Path):
     TMPDIR.mkdir()
     shutil.copytree(data / "bl01t-services/services", TMPDIR / "services")
     shutil.copytree(data / "bl01t-deployment/apps", TMPDIR / "apps")
-    mock_run.run_cli("deploy bl01t-ea-test-01 main")
+    mock_run.run_cli("deploy bl01t-ea-test-01")
 
 
 def test_logs(mock_run, ARGOCD):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,9 +16,9 @@ def test_list(mock_run, CLI, data: Path):
     expect = (
         "| name             | version |\n"
         "|------------------|---------|\n"
-        "| bl01t-ea-test-01 | 3.0     |\n"
-        "| bl01t-ea-test-02 | 3.0     |\n"
-        "| dls-aravis       | 3.0     |\n"
+        "| bl01t-ea-test-01 | 4.0     |\n"
+        "| bl01t-ea-test-02 | 4.0     |\n"
+        "| dls-aravis       | 4.0     |\n"
     )
     mock_run.set_seq(CLI.instances)
     # prep what instances expects to find after it cloned bl01t repo
@@ -33,7 +33,7 @@ def test_instances(mock_run, CLI, data: Path):
     expect = (
         "| version |\n"  # Stops reformating
         "|---------|\n"
-        "| 3.0     |\n"
+        "| 4.0     |\n"
         "| 1.0     |\n"
     )
     mock_run.set_seq(CLI.instances)

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -30,7 +30,7 @@ def test_deploy(mock_run, K8S, data: Path):
     mock_run.set_seq(K8S.deploy)
     # prep what deploy expects to find after it cloned bl01t repo
     shutil.copytree(data / "bl01t-services/services", TMPDIR / "services")
-    mock_run.run_cli("deploy bl01t-ea-test-01 2.0")
+    mock_run.run_cli("deploy bl01t-ea-test-01")
 
 
 def test_exec(mock_run, K8S):


### PR DESCRIPTION
fixes #190 

In this PR I propose that we now gather a list of services for each tag rather than just considering the services available at HEAD of the default branch.
The benefits are:
- Changes to shared files are not flagged as changes to services that arent present at the tag
- You will still see removed services if they have been released in the past

Some additional work:
- Try break up the code a bit
- Restructure to try exit loops of `services` early if a change has been found

Consequences:
- A few more calls to git, so the performance is slightly worse but not noticeably so imo