### PR TITLE
Fix async conversion issues

### DIFF
--- a/src/edge_containers_cli/autocomplete.py
+++ b/src/edge_containers_cli/autocomplete.py
@@ -9,7 +9,7 @@ from edge_containers_cli.cmds.commands import CommandError
 from edge_containers_cli.definitions import ECContext
 from edge_containers_cli.git import GitError, create_version_map
 from edge_containers_cli.shell import ShellError
-from edge_containers_cli.utils import cache_dict, new_workdir, read_cached_dict
+from edge_containers_cli.utils import _run_async, cache_dict, new_workdir, read_cached_dict
 
 
 def url_encode(in_string: str) -> str:
@@ -26,17 +26,19 @@ def autocomplete_backend_init(ctx: typer.Context):
     ec_backend.set_context(context)
 
 
-async def fetch_service_graph(repo: str) -> dict:
+def fetch_service_graph(repo: str) -> dict:
     version_map = read_cached_dict(
         globals.CACHE_ROOT / url_encode(repo), globals.SERVICE_CACHE
     )
     if not version_map:
         with new_workdir() as path:
-            version_map = await create_version_map(
-                repo,
-                Path(globals.SERVICES_DIR),
-                path,
-                shared_files=[globals.SHARED_VALUES],
+            version_map = _run_async(
+                create_version_map(
+                    repo,
+                    Path(globals.SERVICES_DIR),
+                    path,
+                    shared_files=[globals.SHARED_VALUES],
+                )
             )
             cache_dict(
                 globals.CACHE_ROOT / url_encode(repo),
@@ -47,25 +49,25 @@ async def fetch_service_graph(repo: str) -> dict:
     return version_map
 
 
-async def avail_services(ctx: typer.Context) -> list[str]:
+def avail_services(ctx: typer.Context) -> list[str]:
     autocomplete_backend_init(ctx)
 
     # This block prevents getting a stack trace during autocompletion
     try:
-        services_graph = await fetch_service_graph(ec_backend.commands.repo)
+        services_graph = fetch_service_graph(ec_backend.commands.repo)
         return list(services_graph.keys())
     except (ShellError, CommandError) as e:
         typer.echo(f"\n{e}", nl=False, err=True)
         return []
 
 
-async def avail_versions(ctx: typer.Context) -> list[str]:
+def avail_versions(ctx: typer.Context) -> list[str]:
     autocomplete_backend_init(ctx)
     service_name = ctx.params["service_name"]
 
     # This block prevents getting a stack trace during autocompletion
     try:
-        version_map = await fetch_service_graph(ec_backend.commands.repo)
+        version_map = fetch_service_graph(ec_backend.commands.repo)
         svc_versions = version_map[service_name]
         return svc_versions
     except KeyError:

--- a/src/edge_containers_cli/autocomplete.py
+++ b/src/edge_containers_cli/autocomplete.py
@@ -9,7 +9,12 @@ from edge_containers_cli.cmds.commands import CommandError
 from edge_containers_cli.definitions import ECContext
 from edge_containers_cli.git import GitError, create_version_map
 from edge_containers_cli.shell import ShellError
-from edge_containers_cli.utils import _run_async, cache_dict, new_workdir, read_cached_dict
+from edge_containers_cli.utils import (
+    _run_async,
+    cache_dict,
+    new_workdir,
+    read_cached_dict,
+)
 
 
 def url_encode(in_string: str) -> str:

--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -163,7 +163,11 @@ class ArgoCommands(Commands):
             )
 
         if description is None:
-            description = await self._check_description(service_name)
+            try:
+                description = await self._check_description(service_name)
+            except CommandError:
+                # Service not yet deployed — no existing description to retrieve
+                pass
 
         if confirm_callback:
             confirm_callback(version, description)

--- a/src/edge_containers_cli/cmds/k8s_commands.py
+++ b/src/edge_containers_cli/cmds/k8s_commands.py
@@ -141,7 +141,7 @@ class K8sCommands(Commands):
 
         self.sts_dicts = YAML(typ="safe").load(kubectl_res)
 
-    async def _extract_services_df(self, running_only):
+    async def _extract_services_df(self):
         service_data = {
             "name": [],  # type: ignore
             "label": [],
@@ -213,10 +213,7 @@ class K8sCommands(Commands):
 
     async def _get_service_data(self):
         await self._get_services()
-
-        async with asyncio.TaskGroup() as group:
-            for sts in self.sts_dicts:
-                group.create_task(self._extract_services_df(sts))
+        await self._extract_services_df()
 
     def _get_services_df(self, running_only) -> ServicesDataFrame:
         # Clear the current dataframe before polling the current manifests

--- a/src/edge_containers_cli/cmds/monitor.py
+++ b/src/edge_containers_cli/cmds/monitor.py
@@ -551,7 +551,7 @@ class MonitorApp(App):
                         table.update_indicator_threadsafe(
                             service_name, Emoji.road_works
                         )
-                        command(service_name)
+                        _run_async(command(service_name))
                     finally:
                         table.update_indicator_threadsafe(service_name, Emoji.none)
                         self.busy_services.remove(service_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,22 @@ class MockRun:
         response.
         """
         rsp = self._str_command(command, error_OK)
-        assert isinstance(rsp, bool), "non-interactive commands must return bool"
+        assert isinstance(rsp, bool), "interactive commands must return bool"
+
+        return rsp
+
+    def run_interactive_sync(
+        self,
+        command: str,
+        error_OK=False,
+        skip_on_dryrun=False,
+    ) -> bool:
+        """
+        Sync version of run_interactive for mocking sync callables like
+        webbrowser.open that should not be awaited.
+        """
+        rsp = self._str_command(command, error_OK)
+        assert isinstance(rsp, bool), "interactive commands must return bool"
 
         return rsp
 
@@ -156,7 +171,7 @@ def mock_run(mocker):
     )
 
     # Patch functions
-    mocker.patch("webbrowser.open", MOCKRUN.run_interactive)
+    mocker.patch("webbrowser.open", MOCKRUN.run_interactive_sync)
     mocker.patch("typer.confirm", return_value=True)
     mocker.patch("tempfile.mkdtemp", mktempdir)
     mocker.patch("edge_containers_cli.shell.shell.run_command", MOCKRUN.run_command)


### PR DESCRIPTION
## Summary
- Fix k8s `_get_service_data` TaskGroup iterating over dict keys instead of items, causing all k8s tests to fail with `ExceptionGroup`
- Fix `webbrowser.open` mocked with async function, causing `test_log_history` failures
- Fix async autocomplete callbacks (`avail_services`, `avail_versions`) incompatible with typer's sync-only autocompletion
- Fix `deploy` failing for services not yet in argocd (first-time deploy)
- Fix monitor stop/start/restart doing nothing after confirmation (unawaited async commands)

## Test plan
- [x] `pytest tests/` — 34 passed, 0 failed, 0 errors
- [x] Manual test: `ec deploy` for a service not yet in argocd
- [x] Manual test: monitor stop/start/restart via TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)