### PR TITLE
fix(ps): robust manifest parsing and clean asyncio teardown

### DIFF
--- a/src/edge_containers_cli/cmds/argo_commands.py
+++ b/src/edge_containers_cli/cmds/argo_commands.py
@@ -203,13 +203,12 @@ class ArgoCommands(Commands):
         mani_resp = await shell.run_command(
             f"argocd app manifests {namespace}/{service_name} --source live",
         )
-        for resource_manifest in mani_resp.split("---")[1:]:
-            manifest = YAML(typ="safe").load(resource_manifest)
-            if not manifest:
+        for manifest in YAML(typ="safe").load_all(mani_resp):
+            if not isinstance(manifest, dict):
                 continue
-            if manifest["kind"] not in ["StatefulSet", "Deployment"]:
+            if manifest.get("kind") not in ["StatefulSet", "Deployment"]:
                 continue
-            if manifest["metadata"]["name"] != service_name:
+            if manifest.get("metadata", {}).get("name") != service_name:
                 continue
             return manifest
 
@@ -298,12 +297,11 @@ class ArgoCommands(Commands):
                 mani_resp = await shell.run_command(
                     f"argocd app manifests {namespace}/{name} --source live",
                 )
-                for resource_manifest in mani_resp.split("---")[1:]:
-                    manifest = YAML(typ="safe").load(resource_manifest)
-                    if not manifest:
+                for manifest in YAML(typ="safe").load_all(mani_resp):
+                    if not isinstance(manifest, dict):
                         continue
-                    kind = manifest["kind"]
-                    resource_name = manifest["metadata"]["name"]
+                    kind = manifest.get("kind")
+                    resource_name = manifest.get("metadata", {}).get("name")
                     if kind in ["StatefulSet", "Deployment"] and resource_name == name:
                         try:
                             label = manifest["metadata"]["labels"]["description"]

--- a/src/edge_containers_cli/utils.py
+++ b/src/edge_containers_cli/utils.py
@@ -5,6 +5,7 @@ utility functions
 import asyncio
 import contextlib
 import functools
+import gc
 import json
 import os
 import shutil
@@ -234,13 +235,43 @@ def _run_async(coroutine: Coroutine):
         import concurrent.futures
 
         with concurrent.futures.ThreadPoolExecutor() as pool:
-            future = pool.submit(asyncio.run, coroutine)
+            future = pool.submit(_run_on_new_loop, coroutine)
             ret = future.result()  # blocks the worker thread, not the event loop thread
     except RuntimeError:
         # No running loop — safe to block here
-        ret = asyncio.run(coroutine)
+        ret = _run_on_new_loop(coroutine)
 
     return ret
+
+
+def _run_on_new_loop(coroutine: Coroutine):
+    """Run *coroutine* to completion on a fresh event loop, then tear the loop
+    down cleanly.
+
+    asyncio.Process / subprocess transports hold a reference cycle back to the
+    loop, so their __del__ only fires during a GC pass. If that pass happens
+    after the loop is closed (which is what asyncio.run() does on exit), the
+    finalizer schedules a callback on the closed loop and asyncio prints
+    "Event loop is closed" / "Loop ... that handles pid X is closed" spam.
+    Forcing gc.collect() while the loop is still open lets those finalizers
+    run against a live loop, so nothing fails.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coroutine)
+    finally:
+        try:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            gc.collect()
+        finally:
+            loop.close()
 
 
 def async_command(f):


### PR DESCRIPTION
argocd's `--source live` output can contain documents with no `kind` key, or `---` appearing inside values, which broke the naive `split("---")` parser with `KeyError: 'kind'` and `ParserError`. Switch to `YAML.load_all()` and guard against non-resource docs.

Separately, `_run_async` was calling `asyncio.run()`, which closes the loop on exit. asyncio.Process / subprocess transports hold a reference cycle back to the loop, so their `__del__` runs in a later GC pass and prints `Event loop is closed` /
`Loop ... that handles pid X is closed` spam. Own the loop explicitly and force `gc.collect()` before closing so finalizers run against a live loop.